### PR TITLE
Make leadership images square

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -59,3 +59,10 @@ footer {
 .section {
   padding: 3rem 0;
 }
+
+/* Leadership images */
+.card-img-top {
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  object-position: center;
+}


### PR DESCRIPTION
## Summary
- tweak CSS to crop leadership images to a square

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6858c788321c832da930123ddaa10599