### PR TITLE
Add placeholder fallback for images

### DIFF
--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -18,4 +18,16 @@ document.addEventListener('DOMContentLoaded', function () {
         list.appendChild(li);
       });
   }
+
+  const PLACEHOLDER = 'https://via.placeholder.com/500';
+  document.querySelectorAll('img').forEach(img => {
+    if (!img.getAttribute('src')) {
+      img.src = PLACEHOLDER;
+    }
+    img.addEventListener('error', function () {
+      if (img.src !== PLACEHOLDER) {
+        img.src = PLACEHOLDER;
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add JS fallback for missing or broken images

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6858c96e65d4832db334cc52875f02bd