### PR TITLE
Add guest speaker section to homepage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -46,6 +46,16 @@
       <a href="about.html" class="btn btn-primary btn-lg">Learn More</a>
     </section>
 
+    <!-- Guest Speaker Section -->
+    <section class="guest-speaker text-center my-5">
+      <h2 class="h3 mb-3">Guest Speaker of the Week</h2>
+      <h3 class="h4">Alex Johnson</h3>
+      <p class="mx-auto" style="max-width: 600px;">
+        Alex is a senior analyst at Capital Co. who will share tips on
+        building dynamic models in Excel during this week's meeting.
+      </p>
+    </section>
+
     <!-- Instagram Feed Preview -->
     <section class="instagram-feed my-5">
       <h2 class="h3 mb-4 text-center">Latest on Instagram</h2>


### PR DESCRIPTION
## Summary
- add a new "Guest Speaker of the Week" block above the Instagram feed on the homepage

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686f17a8c4c0832db71b69017e054a7c