### PR TITLE
Add multi-photo Instagram slider

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -49,31 +49,39 @@
     <!-- Instagram Feed Preview -->
     <section class="instagram-feed my-5">
       <h2 class="h3 mb-4 text-center">Latest on Instagram</h2>
-      <div id="instaCarousel" class="carousel slide" data-bs-ride="carousel">
-        <div class="carousel-inner">
-          <div class="carousel-item active">
-            <img src="https://via.placeholder.com/800x400" class="d-block w-100" alt="Workshop attendees collaborating">
-            <div class="carousel-caption d-none d-md-block">
-              <small>Mar 12, 2025 • Modeling Workshop</small>
+      <div id="instaSlider" class="insta-slider">
+        <button class="carousel-control-prev insta-prev" type="button">
+          <span class="carousel-control-prev-icon"></span>
+        </button>
+        <div class="insta-track-wrapper">
+          <div class="insta-track">
+            <div class="insta-item">
+              <img src="https://via.placeholder.com/800x400" alt="Workshop attendees collaborating">
+              <small class="d-block text-center mt-1">Mar 12, 2025 • Modeling Workshop</small>
             </div>
-          </div>
-          <div class="carousel-item">
-            <img src="https://via.placeholder.com/800x400" class="d-block w-100" alt="Guest speaker presenting">
-            <div class="carousel-caption d-none d-md-block">
-              <small>Feb 27, 2025 • Guest Speaker</small>
+            <div class="insta-item">
+              <img src="https://via.placeholder.com/800x400" alt="Guest speaker presenting">
+              <small class="d-block text-center mt-1">Feb 27, 2025 • Guest Speaker</small>
             </div>
-          </div>
-          <div class="carousel-item">
-            <img src="https://via.placeholder.com/800x400" class="d-block w-100" alt="Networking social event">
-            <div class="carousel-caption d-none d-md-block">
-              <small>Jan 18, 2025 • Networking Social</small>
+            <div class="insta-item">
+              <img src="https://via.placeholder.com/800x400" alt="Networking social event">
+              <small class="d-block text-center mt-1">Jan 18, 2025 • Networking Social</small>
+            </div>
+            <div class="insta-item">
+              <img src="https://via.placeholder.com/800x400" alt="Team building workshop">
+              <small class="d-block text-center mt-1">Dec 02, 2024 • Team Workshop</small>
+            </div>
+            <div class="insta-item">
+              <img src="https://via.placeholder.com/800x400" alt="Case competition">
+              <small class="d-block text-center mt-1">Nov 20, 2024 • Case Competition</small>
+            </div>
+            <div class="insta-item">
+              <img src="https://via.placeholder.com/800x400" alt="Holiday social">
+              <small class="d-block text-center mt-1">Oct 15, 2024 • Holiday Social</small>
             </div>
           </div>
         </div>
-        <button class="carousel-control-prev" type="button" data-bs-target="#instaCarousel" data-bs-slide="prev">
-          <span class="carousel-control-prev-icon"></span>
-        </button>
-        <button class="carousel-control-next" type="button" data-bs-target="#instaCarousel" data-bs-slide="next">
+        <button class="carousel-control-next insta-next" type="button">
           <span class="carousel-control-next-icon"></span>
         </button>
       </div>

--- a/docs/static/css/app.css
+++ b/docs/static/css/app.css
@@ -66,3 +66,44 @@ footer {
   object-fit: cover;
   object-position: center;
 }
+
+/* Instagram slider */
+.insta-slider {
+  position: relative;
+}
+
+.insta-track-wrapper {
+  overflow: hidden;
+}
+
+.insta-track {
+  display: flex;
+  transition: transform 0.4s ease;
+}
+
+.insta-item {
+  flex: 0 0 20%;
+  padding: 0 0.25rem;
+}
+
+.insta-item img {
+  width: 100%;
+  display: block;
+}
+
+.insta-prev,
+.insta-next {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+}
+
+.insta-prev {
+  left: 0;
+}
+
+.insta-next {
+  right: 0;
+}

--- a/docs/static/js/scripts.js
+++ b/docs/static/js/scripts.js
@@ -30,4 +30,28 @@ document.addEventListener('DOMContentLoaded', function () {
       }
     });
   });
+
+  const slider = document.getElementById('instaSlider');
+  if (slider) {
+    const track = slider.querySelector('.insta-track');
+    const items = slider.querySelectorAll('.insta-item');
+    const visible = 5;
+    let index = 0;
+
+    function update() {
+      track.style.transform = `translateX(-${index * (100 / visible)}%)`;
+    }
+
+    slider.querySelector('.insta-next').addEventListener('click', () => {
+      index = (index + 1) % items.length;
+      update();
+    });
+
+    slider.querySelector('.insta-prev').addEventListener('click', () => {
+      index = (index - 1 + items.length) % items.length;
+      update();
+    });
+
+    update();
+  }
 });


### PR DESCRIPTION
## Summary
- replace single-image carousel with custom 5-photo slider on the home page
- style slider layout in `app.css`
- add JavaScript logic for sliding images one at a time

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686f18d48128832db1c71b663f1257d3