### PR TITLE
Remove join CTA from homepage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -82,14 +82,6 @@
       </p>
     </section>
 
-    <!-- Join CTA -->
-    <section class="join-cta text-center py-5">
-      <h2 class="h3 mb-3">Become a Member Today</h2>
-      <p class="mb-4">
-        All majors welcome! Gain exclusive access to hands-on workshops, one-on-one mentorship, and networking with finance professionals.
-      </p>
-      <a href="join.html" class="btn btn-secondary btn-lg">Join Now</a>
-    </section>
   </main>
 
   <!-- Footer -->


### PR DESCRIPTION
## Summary
- delete the "Become a Member Today" call to action from the homepage

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_b_686f190f1ba8832d84063a987414dcef