### PR TITLE
Adjust footer layout

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -87,8 +87,9 @@
     <div class="container">
       <p class="mb-1">&copy; 2025 William & Mary Financial Modeling Club</p>
       <p>
+        <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank"><i class="fab fa-instagram fa-lg"></i></a>
+        <span class="mx-2">|</span>
         <a href="mailto:financialmodel@wm.edu">financialmodel@wm.edu</a>
-        <a href="https://www.instagram.com/financialmodelingclubwm" class="ms-2" target="_blank"><i class="fab fa-instagram fa-lg"></i></a>
       </p>
     </div>
   </footer>

--- a/docs/index.html
+++ b/docs/index.html
@@ -106,8 +106,9 @@
     <div class="container">
       <p class="mb-1">&copy; 2025 William & Mary Financial Modeling Club</p>
       <p>
+        <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank"><i class="fab fa-instagram fa-lg"></i></a>
+        <span class="mx-2">|</span>
         <a href="mailto:financialmodel@wm.edu">financialmodel@wm.edu</a>
-        <a href="https://www.instagram.com/financialmodelingclubwm" class="ms-2" target="_blank"><i class="fab fa-instagram fa-lg"></i></a>
       </p>
     </div>
   </footer>

--- a/docs/join.html
+++ b/docs/join.html
@@ -55,8 +55,9 @@
     <div class="container">
       <p class="mb-1">&copy; 2025 William & Mary Financial Modeling Club</p>
         <p>
+          <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank"><i class="fab fa-instagram fa-lg"></i></a>
+          <span class="mx-2">|</span>
           <a href="mailto:financialmodel@wm.edu">financialmodel@wm.edu</a>
-          <a href="https://www.instagram.com/financialmodelingclubwm" class="ms-2" target="_blank"><i class="fab fa-instagram fa-lg"></i></a>
         </p>
     </div>
   </footer>

--- a/docs/layout.html
+++ b/docs/layout.html
@@ -55,8 +55,9 @@
     <div class="container">
       <p class="mb-1">&copy; 2025 William & Mary Financial Modeling Club</p>
       <p>
+        <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank"><i class="fab fa-instagram fa-lg"></i></a>
+        <span class="mx-2">|</span>
         <a href="mailto:financialmodel@wm.edu">financialmodel@wm.edu</a>
-        <a href="https://www.instagram.com/financialmodelingclubwm" class="ms-2" target="_blank"><i class="fab fa-instagram fa-lg"></i></a>
       </p>
     </div>
   </footer>

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -196,8 +196,9 @@
     <div class="container">
       <p class="mb-1">&copy; 2025 William & Mary Financial Modeling Club</p>
         <p>
+          <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank"><i class="fab fa-instagram fa-lg"></i></a>
+          <span class="mx-2">|</span>
           <a href="mailto:financialmodel@wm.edu">financialmodel@wm.edu</a>
-          <a href="https://www.instagram.com/financialmodelingclubwm" class="ms-2" target="_blank"><i class="fab fa-instagram fa-lg"></i></a>
         </p>
     </div>
   </footer>

--- a/docs/schedule.html
+++ b/docs/schedule.html
@@ -48,8 +48,9 @@
     <div class="container">
       <p class="mb-1">&copy; 2025 William & Mary Financial Modeling Club</p>
         <p>
+          <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank"><i class="fab fa-instagram fa-lg"></i></a>
+          <span class="mx-2">|</span>
           <a href="mailto:financialmodel@wm.edu">financialmodel@wm.edu</a>
-          <a href="https://www.instagram.com/financialmodelingclubwm" class="ms-2" target="_blank"><i class="fab fa-instagram fa-lg"></i></a>
         </p>
     </div>
   </footer>

--- a/docs/sitemap.html
+++ b/docs/sitemap.html
@@ -48,8 +48,9 @@
     <div class="container">
       <p class="mb-1">&copy; 2025 William & Mary Financial Modeling Club</p>
       <p>
+        <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank"><i class="fab fa-instagram fa-lg"></i></a>
+        <span class="mx-2">|</span>
         <a href="mailto:financialmodel@wm.edu">financialmodel@wm.edu</a>
-        <a href="https://www.instagram.com/financialmodelingclubwm" class="ms-2" target="_blank"><i class="fab fa-instagram fa-lg"></i></a>
       </p>
     </div>
   </footer>


### PR DESCRIPTION
## Summary
- flip order of email and Instagram link in the footer
- add a separator bar between the icon and email

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_686f1d907834832dba6be04c6084dd99