### PR TITLE
Remove underline hover in header

### DIFF
--- a/docs/static/css/app.css
+++ b/docs/static/css/app.css
@@ -47,6 +47,12 @@ a:hover {
   padding: 1rem 0;
 }
 
+/* Remove underline when hovering over header links */
+.navbar .nav-link:hover,
+.navbar .navbar-brand:hover {
+  text-decoration: none;
+}
+
 /* Footer */
 footer {
   font-size: 0.9rem;


### PR DESCRIPTION
## Summary
- disable underline on navbar links when hovered

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686f1fd7b79c832d91b8ef06b329e087