### PR TITLE
Add hover info overlay for leadership page

### DIFF
--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -62,11 +62,13 @@
           <h3 class="h5 mb-3 text-center">President</h3>
           <div class="row g-4 justify-content-center">
             <div class="col-md-4">
-              <div class="card h-100 text-center shadow-sm">
+              <div class="card person-card h-100 text-center shadow-sm">
                 <img src="static/assets/images/DSawyer.jpeg" class="card-img-top" alt="Davis Sawyer">
-                <div class="card-body">
-                  <h5 class="card-title mb-1">Davis Sawyer</h5>
-                  <p class="text-muted mb-2">President &amp; Founder</p>
+                <div class="overlay">
+                  <h5 class="mb-1">Davis Sawyer</h5>
+                  <p class="mb-1">President &amp; Founder</p>
+                  <p class="mb-1">Class of 2026</p>
+                  <p class="mb-0">Finance Major</p>
                 </div>
               </div>
             </div>
@@ -78,12 +80,14 @@
           <div class="row g-4">
             <!-- VP Financial Modeling -->
             <div class="col-md-4">
-              <div class="card h-100 text-center shadow-sm">
+              <div class="card person-card h-100 text-center shadow-sm">
                 <img src="static/assets/images/IMG_3556.JPEG" class="card-img-top" alt="Jack Aitken">
-                <div class="card-body">
-                  <h5 class="card-title mb-1">Jack Aitken</h5>
-                  <p class="text-muted mb-2">VP, Financial Modeling</p>
-                  <a href="https://www.linkedin.com/in/jack-aitken-b516a5282/" target="_blank" class="text-decoration-none">
+                <div class="overlay">
+                  <h5 class="mb-1">Jack Aitken</h5>
+                  <p class="mb-1">VP, Financial Modeling</p>
+                  <p class="mb-1">Class of 2026</p>
+                  <p class="mb-0">Finance Major</p>
+                  <a href="https://www.linkedin.com/in/jack-aitken-b516a5282/" target="_blank" class="text-white mt-2 text-decoration-none">
                     <i class="fab fa-linkedin fa-lg"></i>
                   </a>
                 </div>
@@ -91,12 +95,14 @@
             </div>
             <!-- VP Operations -->
             <div class="col-md-4">
-              <div class="card h-100 text-center shadow-sm">
+              <div class="card person-card h-100 text-center shadow-sm">
                 <img src="static/assets/images/DButler.JPG" class="card-img-top" alt="Danny Butler">
-                <div class="card-body">
-                  <h5 class="card-title mb-1">Danny Butler</h5>
-                  <p class="text-muted mb-2">VP, Operations</p>
-                  <a href="https://www.linkedin.com/in/daniel-butler-a1ba3a296/" target="_blank" class="text-decoration-none">
+                <div class="overlay">
+                  <h5 class="mb-1">Danny Butler</h5>
+                  <p class="mb-1">VP, Operations</p>
+                  <p class="mb-1">Class of 2026</p>
+                  <p class="mb-0">Finance Major</p>
+                  <a href="https://www.linkedin.com/in/daniel-butler-a1ba3a296/" target="_blank" class="text-white mt-2 text-decoration-none">
                     <i class="fab fa-linkedin fa-lg"></i>
                   </a>
                 </div>
@@ -104,12 +110,14 @@
             </div>
             <!-- VP Mentorship -->
             <div class="col-md-4">
-              <div class="card h-100 text-center shadow-sm">
+              <div class="card person-card h-100 text-center shadow-sm">
                 <img src="static/assets/images/TChesnut.JPEG" class="card-img-top" alt="Tom Chesnut">
-                <div class="card-body">
-                  <h5 class="card-title mb-1">Tom Chesnut</h5>
-                  <p class="text-muted mb-2">VP, Mentorship</p>
-                  <a href="https://www.linkedin.com/in/tom-chesnut-2593a329b/" target="_blank" class="text-decoration-none">
+                <div class="overlay">
+                  <h5 class="mb-1">Tom Chesnut</h5>
+                  <p class="mb-1">VP, Mentorship</p>
+                  <p class="mb-1">Class of 2026</p>
+                  <p class="mb-0">Finance Major</p>
+                  <a href="https://www.linkedin.com/in/tom-chesnut-2593a329b/" target="_blank" class="text-white mt-2 text-decoration-none">
                     <i class="fab fa-linkedin fa-lg"></i>
                   </a>
                 </div>
@@ -117,12 +125,14 @@
             </div>
             <!-- VP Corporate Relations -->
             <div class="col-md-4">
-              <div class="card h-100 text-center shadow-sm">
+              <div class="card person-card h-100 text-center shadow-sm">
                 <img src="static/assets/images/AAitken.JPG" class="card-img-top" alt="Alex Aitken">
-                <div class="card-body">
-                  <h5 class="card-title mb-1">Alex Aitken</h5>
-                  <p class="text-muted mb-2">VP, Corporate Relations</p>
-                  <a href="https://www.linkedin.com/in/alex-aitken-1b8b80271/" target="_blank" class="text-decoration-none">
+                <div class="overlay">
+                  <h5 class="mb-1">Alex Aitken</h5>
+                  <p class="mb-1">VP, Corporate Relations</p>
+                  <p class="mb-1">Class of 2026</p>
+                  <p class="mb-0">Finance Major</p>
+                  <a href="https://www.linkedin.com/in/alex-aitken-1b8b80271/" target="_blank" class="text-white mt-2 text-decoration-none">
                     <i class="fab fa-linkedin fa-lg"></i>
                   </a>
                 </div>
@@ -130,12 +140,14 @@
             </div>
             <!-- VP Marketing -->
             <div class="col-md-4">
-              <div class="card h-100 text-center shadow-sm">
+              <div class="card person-card h-100 text-center shadow-sm">
                 <img src="static/assets/images/LArchey.jpg" class="card-img-top" alt="Luke Archey">
-                <div class="card-body">
-                  <h5 class="card-title mb-1">Luke Archey</h5>
-                  <p class="text-muted mb-2">VP, Marketing</p>
-                  <a href="https://www.linkedin.com/in/luke-archey-a23668263/" target="_blank" class="text-decoration-none">
+                <div class="overlay">
+                  <h5 class="mb-1">Luke Archey</h5>
+                  <p class="mb-1">VP, Marketing</p>
+                  <p class="mb-1">Class of 2026</p>
+                  <p class="mb-0">Finance Major</p>
+                  <a href="https://www.linkedin.com/in/luke-archey-a23668263/" target="_blank" class="text-white mt-2 text-decoration-none">
                     <i class="fab fa-linkedin fa-lg"></i>
                   </a>
                 </div>
@@ -143,12 +155,14 @@
             </div>
             <!-- VP Finance -->
             <div class="col-md-4">
-              <div class="card h-100 text-center shadow-sm">
+              <div class="card person-card h-100 text-center shadow-sm">
                 <img src="static/assets/images/BMich.JPG" class="card-img-top" alt="Ben Michaud">
-                <div class="card-body">
-                  <h5 class="card-title mb-1">Ben Michaud</h5>
-                  <p class="text-muted mb-2">VP, Finance</p>
-                  <a href="https://www.linkedin.com/in/benmichaud1/" target="_blank" class="text-decoration-none">
+                <div class="overlay">
+                  <h5 class="mb-1">Ben Michaud</h5>
+                  <p class="mb-1">VP, Finance</p>
+                  <p class="mb-1">Class of 2026</p>
+                  <p class="mb-0">Finance Major</p>
+                  <a href="https://www.linkedin.com/in/benmichaud1/" target="_blank" class="text-white mt-2 text-decoration-none">
                     <i class="fab fa-linkedin fa-lg"></i>
                   </a>
                 </div>
@@ -162,12 +176,14 @@
           <div class="row g-4">
             <!-- Director of Marketing -->
             <div class="col-md-4">
-              <div class="card h-100 text-center shadow-sm">
+              <div class="card person-card h-100 text-center shadow-sm">
                 <img src="static/assets/images/AKochell.JPG" class="card-img-top" alt="Alex Kochell">
-                <div class="card-body">
-                  <h5 class="card-title mb-1">Alex Kochell</h5>
-                  <p class="text-muted mb-2">Director of Marketing</p>
-                  <a href="https://www.linkedin.com/in/alex-kochell-8925492b9/" target="_blank" class="text-decoration-none">
+                <div class="overlay">
+                  <h5 class="mb-1">Alex Kochell</h5>
+                  <p class="mb-1">Director of Marketing</p>
+                  <p class="mb-1">Class of 2026</p>
+                  <p class="mb-0">Finance Major</p>
+                  <a href="https://www.linkedin.com/in/alex-kochell-8925492b9/" target="_blank" class="text-white mt-2 text-decoration-none">
                     <i class="fab fa-linkedin fa-lg"></i>
                   </a>
                 </div>
@@ -175,12 +191,14 @@
             </div>
             <!-- Director of Finance -->
             <div class="col-md-4">
-              <div class="card h-100 text-center shadow-sm">
+              <div class="card person-card h-100 text-center shadow-sm">
                 <img src="static/assets/images/TJander.jpeg" class="card-img-top" alt="Tristan Jander">
-                <div class="card-body">
-                  <h5 class="card-title mb-1">Tristan Jander</h5>
-                  <p class="text-muted mb-2">Director of Finance</p>
-                  <a href="https://www.linkedin.com/in/tristan-jander/" target="_blank" class="text-decoration-none">
+                <div class="overlay">
+                  <h5 class="mb-1">Tristan Jander</h5>
+                  <p class="mb-1">Director of Finance</p>
+                  <p class="mb-1">Class of 2026</p>
+                  <p class="mb-0">Finance Major</p>
+                  <a href="https://www.linkedin.com/in/tristan-jander/" target="_blank" class="text-white mt-2 text-decoration-none">
                     <i class="fab fa-linkedin fa-lg"></i>
                   </a>
                 </div>

--- a/docs/static/css/app.css
+++ b/docs/static/css/app.css
@@ -73,6 +73,34 @@ footer {
   object-position: center;
 }
 
+/* Leadership overlay cards */
+.person-card {
+  position: relative;
+  overflow: hidden;
+}
+
+.person-card .overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  padding: 1rem;
+}
+
+.person-card:hover .overlay {
+  opacity: 1;
+}
+
 /* Instagram slider */
 .insta-slider {
   position: relative;


### PR DESCRIPTION
## Summary
- hide leadership card text until hover
- show name, role, class year and major in overlay

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686f2ed9e7e0832d86eab1004ec3ee5f