### PR TITLE
Reduce leadership page card width

### DIFF
--- a/docs/static/css/app.css
+++ b/docs/static/css/app.css
@@ -77,6 +77,9 @@ footer {
 .person-card {
   position: relative;
   overflow: hidden;
+  max-width: 250px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .person-card .overlay {


### PR DESCRIPTION
## Summary
- restrict width of person-card elements so leadership images render smaller

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686f332a3aa4832da92ee2991c15a69d