### PR TITLE
Remove tagline from leadership page

### DIFF
--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -45,9 +45,6 @@
  
         <h2 class="h3 mb-4 text-center">Executive Board</h2>
         <p class="text-center mx-auto" style="max-width: 700px;">
-          <strong>Our Financial Modeling Club Executive Team</strong>
-        </p>
-        <p class="text-center mx-auto" style="max-width: 700px;">
           The William &amp; Mary FMC E&#8209;Board manages the day&#8209;to&#8209;day
           operations and strategic direction of the club. We collaborate closely
           to design and deliver weekly workshops, events, and networking


### PR DESCRIPTION
## Summary
- remove the text "Our Financial Modeling Club Executive Team" from the leadership page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686f33bb4ad4832d8f438b72a96c56ed