### PR TITLE
Remove headings above leadership photos

### DIFF
--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -56,7 +56,6 @@
         </p>
  
         <div class="p-4 mb-5 border rounded bg-white">
-          <h3 class="h5 mb-3 text-center">President</h3>
           <div class="row g-4 justify-content-center">
             <div class="col-md-4">
               <div class="card person-card h-100 text-center shadow-sm">
@@ -73,7 +72,6 @@
         </div>
 
         <div class="p-4 mb-5 border rounded bg-white">
-          <h3 class="h5 mb-3 text-center">Vice Presidents</h3>
           <div class="row g-4">
             <!-- VP Financial Modeling -->
             <div class="col-md-4">


### PR DESCRIPTION
## Summary
- remove the `President` heading before Davis Sawyer
- remove the `Vice Presidents` heading before the VP section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68702adba0dc832d99beb52818e0c18e