### PR TITLE
Fix LinkedIn icon for Davis Sawyer

### DIFF
--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -65,7 +65,9 @@
                   <p class="mb-1">President &amp; Founder</p>
                   <p class="mb-1">Class of 2027</p>
                   <p class="mb-1">Finance</p>
-                  <a href="https://www.linkedin.com/in/davis-sawyer-wm2027/" target="_blank" class="text-decoration-none">Linkedin</a>
+                  <a href="https://www.linkedin.com/in/davis-sawyer-wm2027/" target="_blank" class="text-decoration-none">
+                    <i class="fab fa-linkedin fa-lg text-primary"></i>
+                  </a>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- show a blue LinkedIn icon for Davis Sawyer on the leadership page

## Testing
- `grep -n "Linkedin" -R docs`


------
https://chatgpt.com/codex/tasks/task_b_6872feef6678832d9297ca96f03a1572