### PR TITLE
Update Davis Sawyer info on leadership page

### DIFF
--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -63,8 +63,7 @@
                 <div class="p-3 text-center">
                   <p class="mb-1">Davis K. Sawyer</p>
                   <p class="mb-1">President &amp; Founder</p>
-                  <p class="mb-1">Class of 2027</p>
-                  <p class="mb-1">Finance</p>
+                  <p class="mb-1">Finance '27</p>
                   <a href="https://www.linkedin.com/in/davis-sawyer-wm2027/" target="_blank" class="text-decoration-none">
                     <i class="fab fa-linkedin fa-lg text-primary"></i>
                   </a>


### PR DESCRIPTION
## Summary
- remove "Class of 2027" line from Davis Sawyer's card
- update his major line to read `Finance '27`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687321b97224832db8f571dfc2b1c9df