### PR TITLE
Fix Danny Butler Education Text

### DIFF
--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -91,7 +91,7 @@
                 <div class="p-3 text-center">
                   <p class="mb-1">Daniel R. Butler</p>
                   <p class="mb-1">VP, Operations</p>
-                  <p class="mb-1">BS Applied Math '25</p>
+                  <p class="mb-1">Applied Math '25</p>
                   <p class="mb-1">MS Computer Science '27</p>
                   <a href="https://www.linkedin.com/in/daniel-butler-a1ba3a296/" target="_blank" class="text-decoration-none">
                     <i class="fab fa-linkedin fa-lg text-primary"></i>


### PR DESCRIPTION
## Summary
- remove `BS` label from Danny Butler's role description on the leadership page

## Testing
- `grep -n "BS Applied" -n`

------
https://chatgpt.com/codex/tasks/task_b_687325c40fac832db1ef0e0dc6738880