### PR TITLE
Fix Executive Board paragraph alignment

### DIFF
--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -44,7 +44,7 @@
       <div class="container">
  
         <h2 class="h3 mb-4 text-center">Executive Board</h2>
-        <p class="text-center mx-auto" style="max-width: 700px;">
+        <p class="mx-auto" style="max-width: 700px; text-align: justify;">
           The William &amp; Mary FMC E&#8209;Board manages the day&#8209;to&#8209;day
           operations and strategic direction of the club. We collaborate closely
           to design and deliver weekly workshops, events, and networking


### PR DESCRIPTION
## Summary
- align the Executive Board description to the left and justify text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687335e0a17c832dad4d517edaf1bf5e