### PR TITLE
Fix directors description alignment

### DIFF
--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -166,10 +166,11 @@
     <section class="section bg-light" style="margin-top: -2rem;">
       <div class="container">
         <h2 class="h3 mb-3 text-center">Directors</h2>
-        <p class="text-center mx-auto" style="max-width: 700px;">
-          Directors support and carry out the goals set by the executive board.
-          They work under the board to keep things running smoothly and help
-          make sure every member has a great experience.
+        <p style="max-width: 700px;">
+          Directors support and carry out the goals set by
+          the executive board. They work under the board to
+          keep things running smoothly and help ensure every
+          member has a great experience.
         </p>
         <div class="p-4 border rounded bg-white">
           <div class="row g-4">


### PR DESCRIPTION
## Summary
- left-align the description paragraph for the Directors section
- rewrap text so lines are evenly sized

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6873366a2f70832d93b96a923ae598d1