### PR TITLE
Fix Directors text justification

### DIFF
--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -166,7 +166,7 @@
     <section class="section bg-light" style="margin-top: -2rem;">
       <div class="container">
         <h2 class="h3 mb-3 text-center">Directors</h2>
-        <p style="max-width: 700px;">
+        <p class="mx-auto" style="max-width: 700px; text-align: justify;">
           Directors support and carry out the goals set by
           the executive board. They work under the board to
           keep things running smoothly and help ensure every


### PR DESCRIPTION
## Summary
- justify copy under the Directors heading on the leadership page

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_68733853c3d0832d88c2c7ed1cd1218d