### PR TITLE
Fix alignment for leadership page

### DIFF
--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -44,7 +44,7 @@
       <div class="container">
  
         <h2 class="h3 mb-4 text-center">Executive Board</h2>
-        <p class="mx-auto" style="max-width: 700px; text-align: justify;">
+        <p class="mx-auto" style="max-width: 700px; text-align: left;">
           The William &amp; Mary FMC E&#8209;Board manages the day&#8209;to&#8209;day
           operations and strategic direction of the club. We collaborate closely
           to design and deliver weekly workshops, events, and networking
@@ -166,7 +166,7 @@
     <section class="section bg-light" style="margin-top: -2rem;">
       <div class="container">
         <h2 class="h3 mb-3 text-center">Directors</h2>
-        <p class="mx-auto" style="max-width: 700px; text-align: justify;">
+        <p class="mx-auto" style="max-width: 700px; text-align: left;">
           Directors support and carry out the goals set by
           the executive board. They work under the board to
           keep things running smoothly and help ensure every


### PR DESCRIPTION
## Summary
- left align leadership page descriptions

## Testing
- `grep -n "text-align:" docs/leadership.html`

------
https://chatgpt.com/codex/tasks/task_b_687339dceab0832d80eaa9c3e79bad15