### PR TITLE
Adjust Executive Board description width

### DIFF
--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -44,7 +44,7 @@
       <div class="container">
  
         <h2 class="h3 mb-4 text-center">Executive Board</h2>
-        <p class="mx-auto" style="max-width: 700px; text-align: left;">
+        <p style="text-align: left;">
           The William &amp; Mary FMC E&#8209;Board manages the day&#8209;to&#8209;day
           operations and strategic direction of the club. We collaborate closely
           to design and deliver weekly workshops, events, and networking


### PR DESCRIPTION
## Summary
- expand the Executive Board description so it spans the page width

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_68733b42dbb0832d99cf3dfb5d4f5833