### PR TITLE
Center headings on about page

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -50,11 +50,11 @@
     <!-- Background & Vision -->
     <section class="section">
       <div class="container">
-        <h2 class="h3 mb-4">Background</h2>
+        <h2 class="h3 mb-4 text-center">Background</h2>
         <p>
           After the original Financial Modeling Club dissolved in 2016, William &amp; Mary students lost a platform to learn essential financial modeling skills for business. In early 2025, a group dedicated to equipping students with the necessary tools for success in finance started the Financial Modeling Club at William &amp; Mary. We aimed to create a simple, welcoming space where people ranging from complete beginners to senior executives find support, build their confidence, and develop practical skills to help them stand out.
         </p>
-        <h2 class="h3 mt-5 mb-4">Mission Statement</h2>
+        <h2 class="h3 mt-5 mb-4 text-center">Mission Statement</h2>
         <p>
           Through hands-on workshops, professional networking, and peer-driven learning, we provide a welcoming space for all students eager to develop and apply financial modeling expertise.
           We're here to help you succeed, and we're excited to have you join us at our next session!


### PR DESCRIPTION
## Summary
- center "Background" and "Mission Statement" headings on the about page

## Testing
- `grep -n "Mission Statement" docs/about.html`


------
https://chatgpt.com/codex/tasks/task_b_6887a62c6414832d84764a1140172c16