### PR TITLE
Add translucent overlay on homepage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -39,10 +39,11 @@
 
   <!-- Page Content -->
   <main class="flex-fill">
+    <div class="home-overlay">
     <!-- Hero Section -->
     <section class="hero home-bg text-center py-5">
       <div class="container">
-        <h1 class="display-4">Welcome to the Financial Modeling Club!</h1>
+        <h1 class="welcome">Welcome to the Financial Modeling Club!</h1>
       </div>
 
     </section>
@@ -105,6 +106,7 @@
       </div>
     </section>
 
+    </div> <!-- end home-overlay -->
   </main>
 
   <!-- Footer -->

--- a/docs/static/css/app.css
+++ b/docs/static/css/app.css
@@ -157,3 +157,15 @@ footer {
 .insta-next {
   right: 0;
 }
+
+/* Translucent container over homepage background */
+.home-overlay {
+  background-color: rgba(255, 255, 255, 0.7);
+  margin: 2rem 0;
+  padding: 2rem 1rem;
+  color: #000;
+}
+
+.home-overlay h1.welcome {
+  font-size: 2rem;
+}


### PR DESCRIPTION
## Summary
- display homepage content inside a translucent white box
- shrink hero heading and ensure all text is black
- update CSS for overlay styling

## Testing
- `npm -v`
- `python3 -m pip list | head`

------
https://chatgpt.com/codex/tasks/task_b_6887bc5b0dcc832da5e98e42d16a3b61