### PR TITLE
Adjust home overlay transparency

### DIFF
--- a/docs/static/css/app.css
+++ b/docs/static/css/app.css
@@ -160,7 +160,7 @@ footer {
 
 /* Translucent container over homepage background */
 .home-overlay {
-  background-color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 255, 255, 0.85);
   margin: 2rem 0;
   padding: 2rem 1rem;
   color: #000;


### PR DESCRIPTION
## Summary
- tweak the `.home-overlay` background to be more opaque

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6887bd68ebf8832d9f446e91773cd73e