### PR TITLE
Tweak layout spacing on homepage

### DIFF
--- a/docs/static/css/app.css
+++ b/docs/static/css/app.css
@@ -55,6 +55,10 @@ a:hover {
   padding: 1rem 0;
 }
 
+body.home-page .navbar {
+  margin-top: 0.5in;
+}
+
 /* Remove underline when hovering over header links */
 .navbar .nav-link:hover,
 .navbar .navbar-brand:hover {
@@ -64,6 +68,9 @@ a:hover {
 /* Footer */
 footer {
   font-size: 0.9rem;
+}
+
+body.home-page footer {
   margin-bottom: 2in;
 }
 
@@ -162,7 +169,7 @@ footer {
 /* Translucent container over homepage background */
 .home-overlay {
   background-color: rgba(255, 255, 255, 0.85);
-  margin: 1in 0 2in;
+  margin: 0 0 2in;
   padding: 2rem 1rem;
   color: #000;
 }


### PR DESCRIPTION
## Summary
- move homepage overlay up so the header has room
- drop footer margin onto just the home page
- give the nav on the homepage top spacing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6887c3cd9f60832da65b807b928b7d0c