### PR TITLE
Remove About Us dropdown arrow

### DIFF
--- a/docs/static/css/app.css
+++ b/docs/static/css/app.css
@@ -197,3 +197,8 @@ body.home-page footer {
     margin-top: 0;
   }
 }
+
+/* Hide the dropdown arrow next to About Us */
+.navbar .dropdown-toggle::after {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- hide the Bootstrap dropdown arrow for the About Us menu item

## Testing
- `none`

------
https://chatgpt.com/codex/tasks/task_b_6887ce2425b0832d943460902e70bef4