### PR TITLE
Move mission statement to homepage

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -63,10 +63,6 @@
         <p>
           After the original Financial Modeling Club dissolved in 2016, William &amp; Mary students lost a platform to learn essential financial modeling skills for business. In early 2025, a group dedicated to equipping students with the necessary tools for success in finance started the Financial Modeling Club at William &amp; Mary. We aimed to create a simple, welcoming space where people ranging from complete beginners to senior executives find support, build their confidence, and develop practical skills to help them stand out.
         </p>
-        <h2 class="h3 mt-5 mb-4 text-center">Mission Statement</h2>
-        <p>
-          Training students in financial modeling through structured workshops, professional mentorship, and recruiting preparation for careers in finance.
-        </p>
       </div>
     </section>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -53,6 +53,7 @@
     <section class="hero home-bg text-center py-3">
       <div class="container">
         <h1 class="welcome">Welcome to the Financial Modeling Club</h1>
+        <p class="lead mt-2">Training students in financial modeling through structured workshops, professional mentorship, and recruiting preparation for careers in finance.</p>
       </div>
 
     </section>


### PR DESCRIPTION
## Summary
- remove Mission Statement section from `Background` page
- show mission statement below the homepage welcome heading

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6887d2ea9528832d97ab68a902e1adc7