### PR TITLE
Add background image for about page

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -9,7 +9,7 @@
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css" rel="stylesheet">
   <link rel="stylesheet" href="static/css/app.css">
 </head>
-<body class="d-flex flex-column min-vh-100">
+<body class="d-flex flex-column min-vh-100 about-page">
 
   <!-- Navbar -->
   <nav class="navbar navbar-expand-lg navbar-light bg-light sticky-top">

--- a/docs/static/css/app.css
+++ b/docs/static/css/app.css
@@ -15,6 +15,13 @@ body.home-page {
   background-position: center;
 }
 
+body.about-page {
+  background: linear-gradient(rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.8)),
+              url('../assets/images/20caeb92-41b0-46c7-8ba1-7cc8ec72541e.jpg');
+  background-size: cover;
+  background-position: center;
+}
+
 /* Color variables */
 :root {
   --primary-color: #00563B;
@@ -123,6 +130,9 @@ body.home-page footer {
   position: relative;
   color: #fff;
   background: none;
+}
+body.about-page .hero {
+  background-color: transparent;
 }
 .section {
   padding: 3rem 0;


### PR DESCRIPTION
## Summary
- apply new background image on the Background page
- keep text readable with light overlay
- make hero section transparent on that page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6887ee5d1498832d94bdb0ed535ed0ba