### PR TITLE
Add background to How We Work page

### DIFF
--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -9,7 +9,7 @@
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css" rel="stylesheet">
   <link rel="stylesheet" href="static/css/app.css">
 </head>
-<body class="d-flex flex-column min-vh-100">
+<body class="d-flex flex-column min-vh-100 howwework-page">
 
   <!-- Navbar -->
   <nav class="navbar navbar-expand-lg navbar-light bg-light sticky-top">
@@ -49,8 +49,7 @@
   <!-- Page Content -->
   <main class="flex-fill container py-5">
     <!-- Intro Banner -->
-    <section class="hero text-center d-flex align-items-center justify-content-center"
-             style="height: 50vh;">
+    <section class="hero text-center d-flex align-items-center justify-content-center">
       <div class="px-4">
         <h1 class="display-4">How We Work</h1>
       </div>

--- a/docs/static/css/app.css
+++ b/docs/static/css/app.css
@@ -22,6 +22,13 @@ body.about-page {
   background-position: center;
 }
 
+body.howwework-page {
+  background: linear-gradient(rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.85)),
+              url('../assets/images/aaaaead2-2275-4517-943f-34f3bfbdd455.jpg');
+  background-size: cover;
+  background-position: center;
+}
+
 /* Color variables */
 :root {
   --primary-color: #00563B;
@@ -133,6 +140,10 @@ body.home-page footer {
 }
 body.about-page .hero {
   background-color: transparent;
+}
+body.howwework-page .hero {
+  background-color: transparent;
+  min-height: calc(100vh - 200px);
 }
 .section {
   padding: 3rem 0;


### PR DESCRIPTION
## Summary
- add howwework page class to use the provided background image
- remove inline hero height and apply page-wide hero styles in CSS
- introduce `.howwework-page` rules in `app.css`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6887f03ffc94832d9bb51bd30411e113