### PR TITLE
Condense content height

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -50,7 +50,7 @@
   <main class="flex-fill container py-5">
     <!-- Intro Banner -->
     <section class="hero text-center d-flex align-items-center justify-content-center"
-             style="height: 50vh;">
+             style="height: 25vh;">
       <div class="px-4">
         <h1 class="display-4">Who We Are</h1>
       </div>

--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -9,7 +9,7 @@
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css" rel="stylesheet">
   <link rel="stylesheet" href="static/css/app.css">
 </head>
-<body class="d-flex flex-column min-vh-100">
+<body class="d-flex flex-column min-vh-100 speaker-page">
 
   <!-- Navbar -->
   <nav class="navbar navbar-expand-lg navbar-light bg-light sticky-top">

--- a/docs/static/css/app.css
+++ b/docs/static/css/app.css
@@ -320,3 +320,37 @@ body.howwework-page .howwework-box {
   -webkit-text-fill-color: transparent;
   color: transparent;
 }
+
+/* Condensed layout adjustments to avoid scrolling on most pages */
+body.home-page .home-overlay {
+  margin: 0.25in 0;
+}
+
+body.home-page .hero.home-bg {
+  min-height: 25vh;
+}
+
+body.home-page .instagram-feed .insta-item img {
+  height: 120px;
+  object-fit: cover;
+}
+
+body.about-page .hero {
+  height: 25vh;
+}
+
+body.howwework-page .howwework-box {
+  margin-left: 2in;
+  margin-right: 2in;
+  min-height: 25vh;
+}
+
+body.speaker-page .section {
+  padding: 1rem 0;
+}
+
+body.home-page .section,
+body.about-page .section,
+body.howwework-page .section {
+  padding: 1rem 0;
+}


### PR DESCRIPTION
## Summary
- adjust home, about, how we work and speaker pages to reduce vertical space
- add speaker-page class
- lower hero heights and section padding in CSS

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_688a980d0b44832d8723a8bd451e8640