### PR TITLE
feat: add delayed typing to homepage message

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
       <section class="text-center py-3">
         <div class="max-w-4xl mx-auto">
           <h1 class="text-2xl font-bold text-green-700">Welcome to the Financial Modeling Club</h1>
-          <p class="mt-2 italic">Combining advice from professionals in finance with student-led workshops to develop essential financial modeling skills</p>
+          <p id="intro-message" class="mt-2 italic" data-message="Combining advice from professionals in finance with student-led workshops to develop essential financial modeling skills"></p>
         </div>
       </section>
 

--- a/docs/static/js/scripts.js
+++ b/docs/static/js/scripts.js
@@ -19,6 +19,22 @@ document.addEventListener('DOMContentLoaded', function () {
       });
   }
 
+  const intro = document.getElementById('intro-message');
+  if (intro) {
+    const text = intro.dataset.message;
+    intro.textContent = '';
+    setTimeout(() => {
+      let i = 0;
+      const interval = setInterval(() => {
+        intro.textContent = text.slice(0, i + 1);
+        i++;
+        if (i === text.length) {
+          clearInterval(interval);
+        }
+      }, 50);
+    }, 2000);
+  }
+
   const PLACEHOLDER = 'https://unsplash.it/500/500';
   document.querySelectorAll('img').forEach(img => {
     if (!img.getAttribute('src')) {


### PR DESCRIPTION
## Summary
- animate homepage intro message typing in after a short delay
- support introductory text via JS typing effect

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688d808f30b0832d9c78d56ac737fbad