### PR TITLE
Add double-sided card component

### DIFF
--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -34,8 +34,17 @@
   <main class="flex-grow py-8 glass m-4">
     <section class="max-w-3xl mx-auto px-4 text-center">
       <h1 class="text-3xl font-bold mb-4">Speaker of the Week</h1>
-      <h2 class="text-xl font-semibold">Alex Johnson</h2>
-      <p class="mt-4">Alex is a senior analyst at Capital Co. who will share tips on building dynamic models in Excel during this week's meeting.</p>
+      <div class="card">
+        <div class="card-inner">
+          <div class="card-front flex flex-col">
+            <h2 class="text-xl font-semibold">Alex Johnson</h2>
+            <p class="mt-2 text-sm">Senior Analyst, Capital Co.</p>
+          </div>
+          <div class="card-back p-4 flex flex-col">
+            <p>Alex will share tips on building dynamic models in Excel during this week's meeting.</p>
+          </div>
+        </div>
+      </div>
     </section>
   </main>
 

--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -6,3 +6,48 @@
   border: 1px solid rgba(255, 255, 255, 0.3);
   box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
 }
+
+/* Double-sided card component */
+.card {
+  width: 200px;
+  height: 250px;
+  margin: 1rem auto;
+  perspective: 1000px;
+  cursor: pointer;
+}
+
+.card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.6s;
+  transform-style: preserve-3d;
+}
+
+.card:hover .card-inner {
+  transform: rotateY(180deg);
+}
+
+.card-front,
+.card-back {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  backface-visibility: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.5rem;
+}
+
+.card-front {
+  background: white;
+  border: 1px solid #e5e7eb;
+}
+
+.card-back {
+  background: #8b5cf6;
+  color: white;
+  transform: rotateY(180deg);
+}
+


### PR DESCRIPTION
## Summary
- add CSS for a hover-driven double-sided card
- use the new card on the speaker page to reveal details on flip

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688d80faa58c832db24f9dd924e7891a