### PR TITLE
fix: prevent nav from stretching full height

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -9,11 +9,10 @@
 
 /* Liquid morph button styles */
 .liquid-morph-container {
+  /* Keep nav list compact without full-page height or background */
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 100vh;
-  background: #001;
 }
 
 .liquid-morph-element {


### PR DESCRIPTION
## Summary
- remove full viewport height and background color from `.liquid-morph-container` so nav links display correctly

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688d85873818832d9579accd61c979ca