### PR TITLE
Add animated Instagram marquee

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -43,37 +43,59 @@
       <section class="my-3">
         <div class="max-w-4xl mx-auto">
           <h2 class="text-xl font-bold mb-4 text-center">Latest on Instagram</h2>
-          <div id="instaSlider" class="relative overflow-hidden">
-            <button class="insta-prev absolute left-0 top-1/2 -translate-y-1/2 p-2 glass rounded-full">&#10094;</button>
-            <div class="insta-track-wrapper overflow-hidden">
-              <div class="insta-track flex transition-transform duration-300">
-                <div class="insta-item shrink-0 basis-[20%] px-2">
-                  <img src="https://unsplash.it/800/400" alt="Workshop attendees collaborating" class="h-32 w-full object-cover">
-                  <small class="block text-center mt-1">Mar 12, 2025 • Modeling Workshop</small>
-                </div>
-                <div class="insta-item shrink-0 basis-[20%] px-2">
-                  <img src="https://unsplash.it/800/400" alt="Guest speaker presenting" class="h-32 w-full object-cover">
-                  <small class="block text-center mt-1">Feb 27, 2025 • Guest Speaker</small>
-                </div>
-                <div class="insta-item shrink-0 basis-[20%] px-2">
-                  <img src="https://unsplash.it/800/400" alt="Networking social event" class="h-32 w-full object-cover">
-                  <small class="block text-center mt-1">Jan 18, 2025 • Networking Social</small>
-                </div>
-                <div class="insta-item shrink-0 basis-[20%] px-2">
-                  <img src="https://unsplash.it/800/400" alt="Team building workshop" class="h-32 w-full object-cover">
-                  <small class="block text-center mt-1">Dec 02, 2024 • Team Workshop</small>
-                </div>
-                <div class="insta-item shrink-0 basis-[20%] px-2">
-                  <img src="https://unsplash.it/800/400" alt="Case competition" class="h-32 w-full object-cover">
-                  <small class="block text-center mt-1">Nov 20, 2024 • Case Competition</small>
-                </div>
-                <div class="insta-item shrink-0 basis-[20%] px-2">
-                  <img src="https://unsplash.it/800/400" alt="Holiday social" class="h-32 w-full object-cover">
-                  <small class="block text-center mt-1">Oct 15, 2024 • Holiday Social</small>
-                </div>
+          <div class="insta-marquee">
+            <div class="insta-row insta-row-fast">
+              <div class="insta-item glass p-2 mr-4 flex-none">
+                <img src="https://unsplash.it/800/400" alt="Workshop attendees collaborating" class="h-32 w-32 object-cover rounded-md">
+                <small class="block text-center mt-1">Mar 12, 2025 • Modeling Workshop</small>
+              </div>
+              <div class="insta-item glass p-2 mr-4 flex-none">
+                <img src="https://unsplash.it/800/400" alt="Guest speaker presenting" class="h-32 w-32 object-cover rounded-md">
+                <small class="block text-center mt-1">Feb 27, 2025 • Guest Speaker</small>
+              </div>
+              <div class="insta-item glass p-2 mr-4 flex-none">
+                <img src="https://unsplash.it/800/400" alt="Networking social event" class="h-32 w-32 object-cover rounded-md">
+                <small class="block text-center mt-1">Jan 18, 2025 • Networking Social</small>
+              </div>
+              <div class="insta-item glass p-2 mr-4 flex-none">
+                <img src="https://unsplash.it/800/400" alt="Team building workshop" class="h-32 w-32 object-cover rounded-md">
+                <small class="block text-center mt-1">Dec 02, 2024 • Team Workshop</small>
+              </div>
+              <div class="insta-item glass p-2 mr-4 flex-none">
+                <img src="https://unsplash.it/800/400" alt="Case competition" class="h-32 w-32 object-cover rounded-md">
+                <small class="block text-center mt-1">Nov 20, 2024 • Case Competition</small>
+              </div>
+              <div class="insta-item glass p-2 mr-4 flex-none">
+                <img src="https://unsplash.it/800/400" alt="Holiday social" class="h-32 w-32 object-cover rounded-md">
+                <small class="block text-center mt-1">Oct 15, 2024 • Holiday Social</small>
               </div>
             </div>
-            <button class="insta-next absolute right-0 top-1/2 -translate-y-1/2 p-2 glass rounded-full">&#10095;</button>
+            <div class="insta-row insta-row-slow">
+              <div class="insta-item glass p-2 mr-4 flex-none">
+                <img src="https://unsplash.it/800/400" alt="Workshop attendees collaborating" class="h-32 w-32 object-cover rounded-md">
+                <small class="block text-center mt-1">Mar 12, 2025 • Modeling Workshop</small>
+              </div>
+              <div class="insta-item glass p-2 mr-4 flex-none">
+                <img src="https://unsplash.it/800/400" alt="Guest speaker presenting" class="h-32 w-32 object-cover rounded-md">
+                <small class="block text-center mt-1">Feb 27, 2025 • Guest Speaker</small>
+              </div>
+              <div class="insta-item glass p-2 mr-4 flex-none">
+                <img src="https://unsplash.it/800/400" alt="Networking social event" class="h-32 w-32 object-cover rounded-md">
+                <small class="block text-center mt-1">Jan 18, 2025 • Networking Social</small>
+              </div>
+              <div class="insta-item glass p-2 mr-4 flex-none">
+                <img src="https://unsplash.it/800/400" alt="Team building workshop" class="h-32 w-32 object-cover rounded-md">
+                <small class="block text-center mt-1">Dec 02, 2024 • Team Workshop</small>
+              </div>
+              <div class="insta-item glass p-2 mr-4 flex-none">
+                <img src="https://unsplash.it/800/400" alt="Case competition" class="h-32 w-32 object-cover rounded-md">
+                <small class="block text-center mt-1">Nov 20, 2024 • Case Competition</small>
+              </div>
+              <div class="insta-item glass p-2 mr-4 flex-none">
+                <img src="https://unsplash.it/800/400" alt="Holiday social" class="h-32 w-32 object-cover rounded-md">
+                <small class="block text-center mt-1">Oct 15, 2024 • Holiday Social</small>
+              </div>
+            </div>
           </div>
           <p class="mt-3 text-center">
             <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" class="text-green-700 hover:underline">Follow Us</a>

--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -105,3 +105,33 @@
   color: white;
   transform: rotateY(180deg);
 }
+
+/* Instagram marquee */
+.insta-marquee {
+  overflow: hidden;
+  position: relative;
+}
+
+.insta-row {
+  display: flex;
+  width: max-content;
+}
+
+.insta-row-fast {
+  animation: insta-scroll 20s linear infinite;
+}
+
+.insta-row-slow {
+  animation: insta-scroll 30s linear infinite;
+  animation-delay: -15s;
+  margin-top: 1rem;
+}
+
+@keyframes insta-scroll {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-50%);
+  }
+}

--- a/docs/static/js/scripts.js
+++ b/docs/static/js/scripts.js
@@ -46,28 +46,8 @@ document.addEventListener('DOMContentLoaded', function () {
       }
     });
   });
-
-  const slider = document.getElementById('instaSlider');
-  if (slider) {
-    const track = slider.querySelector('.insta-track');
-    const items = slider.querySelectorAll('.insta-item');
-    const visible = 5;
-    let index = 0;
-
-    function update() {
-      track.style.transform = `translateX(-${index * (100 / visible)}%)`;
-    }
-
-    slider.querySelector('.insta-next').addEventListener('click', () => {
-      index = (index + 1) % items.length;
-      update();
-    });
-
-    slider.querySelector('.insta-prev').addEventListener('click', () => {
-      index = (index - 1 + items.length) % items.length;
-      update();
-    });
-
-    update();
-  }
+  const instaRows = document.querySelectorAll('.insta-row');
+  instaRows.forEach(row => {
+    row.innerHTML += row.innerHTML;
+  });
 });


### PR DESCRIPTION
## Summary
- Replace manual Instagram slider with two-row marquee that scrolls from right to left
- Style marquee items with glassmorphic effect matching team cards
- Add animation utilities and script to duplicate rows for seamless motion

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_b_688d8a7d2d40832dae5aef84e6dea2d8