### PR TITLE
Use Inter font across site

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>About Us – Financial Modeling Club at William & Mary</title>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css" rel="stylesheet">
   <link href="static/css/glass.css" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
@@ -16,7 +16,7 @@
         <a href="index.html" class="flex items-center">
           <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           <div class="ml-2">
-            <span class="block text-3xl font-serif">FMCWM</span>
+            <span class="block text-3xl">FMCWM</span>
             <span class="block text-sm">Financial Modeling Club at William & Mary</span>
           </div>
         </a>

--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>How We Work – Financial Modeling Club at William & Mary</title>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css" rel="stylesheet">
   <link href="static/css/glass.css" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
@@ -16,7 +16,7 @@
         <a href="index.html" class="flex items-center">
           <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           <div class="ml-2">
-            <span class="block text-3xl font-serif">FMCWM</span>
+            <span class="block text-3xl">FMCWM</span>
             <span class="block text-sm">Financial Modeling Club at William & Mary</span>
           </div>
         </a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Home – Financial Modeling Club at William & Mary</title>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css" rel="stylesheet">
   <link href="static/css/glass.css" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
@@ -16,7 +16,7 @@
         <a href="index.html" class="flex items-center">
           <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           <div class="ml-2">
-            <span class="block text-3xl font-serif">FMCWM</span>
+            <span class="block text-3xl">FMCWM</span>
             <span class="block text-sm">Financial Modeling Club at William & Mary</span>
           </div>
         </a>

--- a/docs/join.html
+++ b/docs/join.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Join – Financial Modeling Club at William & Mary</title>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css" rel="stylesheet">
   <link href="static/css/glass.css" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
@@ -16,7 +16,7 @@
         <a href="index.html" class="flex items-center">
           <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           <div class="ml-2">
-            <span class="block text-3xl font-serif">FMCWM</span>
+            <span class="block text-3xl">FMCWM</span>
             <span class="block text-sm">Financial Modeling Club at William & Mary</span>
           </div>
         </a>

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Leadership – Financial Modeling Club at William & Mary</title>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css" rel="stylesheet">
   <link href="static/css/glass.css" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
@@ -16,7 +16,7 @@
         <a href="index.html" class="flex items-center">
           <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           <div class="ml-2">
-            <span class="block text-3xl font-serif">FMCWM</span>
+            <span class="block text-3xl">FMCWM</span>
             <span class="block text-sm">Financial Modeling Club at William & Mary</span>
           </div>
         </a>

--- a/docs/schedule.html
+++ b/docs/schedule.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Schedule – Financial Modeling Club at William & Mary</title>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css" rel="stylesheet">
   <link href="static/css/glass.css" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
@@ -16,7 +16,7 @@
         <a href="index.html" class="flex items-center">
           <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           <div class="ml-2">
-            <span class="block text-3xl font-serif">FMCWM</span>
+            <span class="block text-3xl">FMCWM</span>
             <span class="block text-sm">Financial Modeling Club at William & Mary</span>
           </div>
         </a>

--- a/docs/sitemap.html
+++ b/docs/sitemap.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Sitemap – Financial Modeling Club at William & Mary</title>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css" rel="stylesheet">
   <link href="static/css/glass.css" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
@@ -16,7 +16,7 @@
         <a href="index.html" class="flex items-center">
           <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           <div class="ml-2">
-            <span class="block text-3xl font-serif">FMCWM</span>
+            <span class="block text-3xl">FMCWM</span>
             <span class="block text-sm">Financial Modeling Club at William & Mary</span>
           </div>
         </a>

--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Speaker of the Week – Financial Modeling Club at William & Mary</title>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css" rel="stylesheet">
   <link href="static/css/glass.css" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
@@ -16,7 +16,7 @@
         <a href="index.html" class="flex items-center">
           <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           <div class="ml-2">
-            <span class="block text-3xl font-serif">FMCWM</span>
+            <span class="block text-3xl">FMCWM</span>
             <span class="block text-sm">Financial Modeling Club at William & Mary</span>
           </div>
         </a>

--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -1,3 +1,5 @@
+body { font-family: "Inter", sans-serif; }
+
 .glass {
   background: rgba(255, 255, 255, 0.2);
   border-radius: 1rem;


### PR DESCRIPTION
## Summary
- switch all pages to Inter via Google Fonts
- remove old serif classes so navigation text uses Inter
- set Inter as default font family in CSS

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688d8d0d7a88832dbabf3341d88e3bbc