### PR TITLE
Use OpenAI color palette

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -1,3 +1,9 @@
+:root {
+  --openai-black: #000000;
+  --openai-white: #FFFFFF;
+  --chatgpt-green: #00A67E;
+}
+
 .glass {
   background: rgba(255, 255, 255, 0.2);
   border-radius: 1rem;
@@ -16,7 +22,7 @@
 }
 
 .liquid-morph-element {
-  background: #0a2342;
+  background: var(--chatgpt-green);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -28,7 +34,7 @@
 }
 
 .liquid-morph-element span {
-  color: #fff;
+  color: var(--openai-white);
   font-size: 1rem;
   position: relative;
   z-index: 2;
@@ -42,9 +48,9 @@
   width: 100%;
   height: 100%;
   background: conic-gradient(
-    #0ff 0deg,
-    #0a2342 120deg,
-    #0ff 240deg
+    var(--chatgpt-green) 0deg,
+    var(--openai-black) 120deg,
+    var(--chatgpt-green) 240deg
   );
   transition: all 0.6s ease;
   opacity: 0;
@@ -102,7 +108,7 @@
 }
 
 .card-back {
-  color: white;
+  color: var(--openai-white);
   transform: rotateY(180deg);
 }
 


### PR DESCRIPTION
## Summary
- add CSS variables for OpenAI black, white, and ChatGPT green
- style navigation and cards with new palette

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688d8d1d3324832d85562954fdbd3324