### PR TITLE
Fix card back color for team page

### DIFF
--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -48,7 +48,7 @@
               <div class="card-back p-4">
                 <p class="font-semibold">Davis K. Sawyer</p>
                 <p class="text-sm mb-2">Finance '27</p>
-                <a href="https://www.linkedin.com/in/davis-sawyer-wm2027/" target="_blank" class="text-white"><i class="fab fa-linkedin fa-lg"></i></a>
+                <a href="https://www.linkedin.com/in/davis-sawyer-wm2027/" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
               </div>
             </div>
           </div>
@@ -62,7 +62,7 @@
               <div class="card-back p-4">
                 <p class="font-semibold">Jack W. Aitken</p>
                 <p class="text-sm mb-2">Computer Science '27</p>
-                <a href="https://www.linkedin.com/in/jack-aitken-b516a5282/" target="_blank" class="text-white"><i class="fab fa-linkedin fa-lg"></i></a>
+                <a href="https://www.linkedin.com/in/jack-aitken-b516a5282/" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
               </div>
             </div>
           </div>
@@ -77,7 +77,7 @@
                 <p class="font-semibold">Daniel R. Butler</p>
                 <p class="text-sm">Applied Math '25</p>
                 <p class="text-sm mb-2">MS Computer Science '27</p>
-                <a href="https://www.linkedin.com/in/daniel-butler-a1ba3a296/" target="_blank" class="text-white"><i class="fab fa-linkedin fa-lg"></i></a>
+                <a href="https://www.linkedin.com/in/daniel-butler-a1ba3a296/" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
               </div>
             </div>
           </div>
@@ -91,7 +91,7 @@
               <div class="card-back p-4">
                 <p class="font-semibold">Tom G. Chesnut</p>
                 <p class="text-sm mb-2">History &amp; Religion '27</p>
-                <a href="https://www.linkedin.com/in/tom-chesnut-2593a329b/" target="_blank" class="text-white"><i class="fab fa-linkedin fa-lg"></i></a>
+                <a href="https://www.linkedin.com/in/tom-chesnut-2593a329b/" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
               </div>
             </div>
           </div>
@@ -105,7 +105,7 @@
               <div class="card-back p-4">
                 <p class="font-semibold">Luke X. Archey</p>
                 <p class="text-sm mb-2">Economics '26</p>
-                <a href="https://www.linkedin.com/in/luke-archey-a23668263/" target="_blank" class="text-white"><i class="fab fa-linkedin fa-lg"></i></a>
+                <a href="https://www.linkedin.com/in/luke-archey-a23668263/" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
               </div>
             </div>
           </div>
@@ -119,7 +119,7 @@
               <div class="card-back p-4">
                 <p class="font-semibold">Ben L. Michaud</p>
                 <p class="text-sm mb-2">Economics '26</p>
-                <a href="https://www.linkedin.com/in/benmichaud1/" target="_blank" class="text-white"><i class="fab fa-linkedin fa-lg"></i></a>
+                <a href="https://www.linkedin.com/in/benmichaud1/" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
               </div>
             </div>
           </div>
@@ -142,7 +142,7 @@
               <div class="card-back p-4">
                 <p class="font-semibold">Audrey P. Sims</p>
                 <p class="text-sm mb-2">Finance '27</p>
-                <a href="https://www.linkedin.com/in/audreysims" target="_blank" class="text-white"><i class="fab fa-linkedin fa-lg"></i></a>
+                <a href="https://www.linkedin.com/in/audreysims" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
               </div>
             </div>
           </div>
@@ -156,7 +156,7 @@
               <div class="card-back p-4">
                 <p class="font-semibold">Tristan C. Jander</p>
                 <p class="text-sm mb-2">Accounting '27</p>
-                <a href="https://www.linkedin.com/in/tristan-jander/" target="_blank" class="text-white"><i class="fab fa-linkedin fa-lg"></i></a>
+                <a href="https://www.linkedin.com/in/tristan-jander/" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
               </div>
             </div>
           </div>
@@ -170,7 +170,7 @@
               <div class="card-back p-4">
                 <p class="font-semibold">Alex R. Kochell</p>
                 <p class="text-sm mb-2">Finance '27</p>
-                <a href="https://www.linkedin.com/in/alex-kochell-8925492b9/" target="_blank" class="text-white"><i class="fab fa-linkedin fa-lg"></i></a>
+                <a href="https://www.linkedin.com/in/alex-kochell-8925492b9/" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
               </div>
             </div>
           </div>

--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -102,7 +102,7 @@
 }
 
 .card-back {
-  color: white;
+  color: black;
   transform: rotateY(180deg);
 }
 


### PR DESCRIPTION
## Summary
- make team card back text black for readability
- use black LinkedIn icons on leadership page

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*
- `pre-commit run --files docs/leadership.html docs/static/css/glass.css` *(fails: command not found, install attempted but failed due to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_688d8dad82a4832daf7513d939698cb4