### PR TITLE
style: darken team cards and add image background

### DIFF
--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -9,7 +9,7 @@
   <link href="static/css/glass.css" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="flex flex-col min-h-screen bg-gradient-to-br from-green-200 to-green-50">
+<body class="flex flex-col min-h-screen team-bg">
   <nav class="glass shadow rounded-none">
     <div class="max-w-7xl mx-auto px-4">
       <div class="flex items-center py-4">
@@ -48,7 +48,7 @@
               <div class="card-back p-4">
                 <p class="font-semibold">Davis K. Sawyer</p>
                 <p class="text-sm mb-2">Finance '27</p>
-                <a href="https://www.linkedin.com/in/davis-sawyer-wm2027/" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
+                <a href="https://www.linkedin.com/in/davis-sawyer-wm2027/" target="_blank" class="text-white"><i class="fab fa-linkedin fa-lg"></i></a>
               </div>
             </div>
           </div>
@@ -62,7 +62,7 @@
               <div class="card-back p-4">
                 <p class="font-semibold">Jack W. Aitken</p>
                 <p class="text-sm mb-2">Computer Science '27</p>
-                <a href="https://www.linkedin.com/in/jack-aitken-b516a5282/" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
+                <a href="https://www.linkedin.com/in/jack-aitken-b516a5282/" target="_blank" class="text-white"><i class="fab fa-linkedin fa-lg"></i></a>
               </div>
             </div>
           </div>
@@ -77,7 +77,7 @@
                 <p class="font-semibold">Daniel R. Butler</p>
                 <p class="text-sm">Applied Math '25</p>
                 <p class="text-sm mb-2">MS Computer Science '27</p>
-                <a href="https://www.linkedin.com/in/daniel-butler-a1ba3a296/" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
+                <a href="https://www.linkedin.com/in/daniel-butler-a1ba3a296/" target="_blank" class="text-white"><i class="fab fa-linkedin fa-lg"></i></a>
               </div>
             </div>
           </div>
@@ -91,7 +91,7 @@
               <div class="card-back p-4">
                 <p class="font-semibold">Tom G. Chesnut</p>
                 <p class="text-sm mb-2">History &amp; Religion '27</p>
-                <a href="https://www.linkedin.com/in/tom-chesnut-2593a329b/" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
+                <a href="https://www.linkedin.com/in/tom-chesnut-2593a329b/" target="_blank" class="text-white"><i class="fab fa-linkedin fa-lg"></i></a>
               </div>
             </div>
           </div>
@@ -105,7 +105,7 @@
               <div class="card-back p-4">
                 <p class="font-semibold">Luke X. Archey</p>
                 <p class="text-sm mb-2">Economics '26</p>
-                <a href="https://www.linkedin.com/in/luke-archey-a23668263/" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
+                <a href="https://www.linkedin.com/in/luke-archey-a23668263/" target="_blank" class="text-white"><i class="fab fa-linkedin fa-lg"></i></a>
               </div>
             </div>
           </div>
@@ -119,7 +119,7 @@
               <div class="card-back p-4">
                 <p class="font-semibold">Ben L. Michaud</p>
                 <p class="text-sm mb-2">Economics '26</p>
-                <a href="https://www.linkedin.com/in/benmichaud1/" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
+                <a href="https://www.linkedin.com/in/benmichaud1/" target="_blank" class="text-white"><i class="fab fa-linkedin fa-lg"></i></a>
               </div>
             </div>
           </div>
@@ -142,7 +142,7 @@
               <div class="card-back p-4">
                 <p class="font-semibold">Audrey P. Sims</p>
                 <p class="text-sm mb-2">Finance '27</p>
-                <a href="https://www.linkedin.com/in/audreysims" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
+                <a href="https://www.linkedin.com/in/audreysims" target="_blank" class="text-white"><i class="fab fa-linkedin fa-lg"></i></a>
               </div>
             </div>
           </div>
@@ -156,7 +156,7 @@
               <div class="card-back p-4">
                 <p class="font-semibold">Tristan C. Jander</p>
                 <p class="text-sm mb-2">Accounting '27</p>
-                <a href="https://www.linkedin.com/in/tristan-jander/" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
+                <a href="https://www.linkedin.com/in/tristan-jander/" target="_blank" class="text-white"><i class="fab fa-linkedin fa-lg"></i></a>
               </div>
             </div>
           </div>
@@ -170,7 +170,7 @@
               <div class="card-back p-4">
                 <p class="font-semibold">Alex R. Kochell</p>
                 <p class="text-sm mb-2">Finance '27</p>
-                <a href="https://www.linkedin.com/in/alex-kochell-8925492b9/" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
+                <a href="https://www.linkedin.com/in/alex-kochell-8925492b9/" target="_blank" class="text-white"><i class="fab fa-linkedin fa-lg"></i></a>
               </div>
             </div>
           </div>

--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -10,6 +10,29 @@ body {
 
 }
 
+.team-bg {
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+  animation: team-slideshow 60s infinite;
+}
+
+@keyframes team-slideshow {
+  0% {
+    background-image: url('../assets/images/20caeb92-41b0-46c7-8ba1-7cc8ec72541e.jpg');
+  }
+  33% {
+    background-image: url('../assets/images/297db81b-4a12-4c0b-b739-5fcb7aa892cc.jpg');
+  }
+  66% {
+    background-image: url('../assets/images/aaaaead2-2275-4517-943f-34f3bfbdd455.jpg');
+  }
+  100% {
+    background-image: url('../assets/images/b6e68641-5167-4bcc-b653-3d3339c5366c.jpg');
+  }
+}
+
 .glass {
   background: rgba(255, 255, 255, 0.2);
   border-radius: 1rem;
@@ -106,7 +129,8 @@ body {
   justify-content: center;
   border-radius: 0.5rem;
   text-align: center;
-  background: rgba(255, 255, 255, 0.1);
+  background: rgba(0, 0, 0, 0.8);
+  color: white;
   border: 1px solid rgba(255, 255, 255, 0.3);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
@@ -114,9 +138,6 @@ body {
 }
 
 .card-back {
-
-  color: black;
-
   transform: rotateY(180deg);
 }
 


### PR DESCRIPTION
## Summary
- switch team page layout to image-driven background
- restyle team member cards with dark theme and white icons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688d8ef0bab0832d93a65cbf9e315848