### PR TITLE
feat: render site as single page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -13,7 +13,7 @@
   <nav class="glass shadow rounded-none">
     <div class="max-w-7xl mx-auto px-4">
       <div class="flex items-center py-4">
-        <a href="index.html" class="flex items-center">
+        <a href="#home" class="flex items-center">
           <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           <div class="ml-2">
             <span class="block text-3xl">FMCWM</span>
@@ -21,18 +21,18 @@
           </div>
         </a>
         <ul class="liquid-morph-container flex space-x-4 justify-center flex-1">
-          <li><a href="index.html" class="liquid-morph-element"><span>Home</span></a></li>
-          <li><a href="howwework.html" class="liquid-morph-element"><span>Meetings</span></a></li>
-          <li><a href="leadership.html" class="liquid-morph-element"><span>Our Team</span></a></li>
-          <li><a href="schedule.html" class="liquid-morph-element"><span>Schedule</span></a></li>
+          <li><a href="#home" class="liquid-morph-element"><span>Home</span></a></li>
+          <li><a href="#howwework" class="liquid-morph-element"><span>Meetings</span></a></li>
+          <li><a href="#leadership" class="liquid-morph-element"><span>Our Team</span></a></li>
+          <li><a href="#schedule" class="liquid-morph-element"><span>Schedule</span></a></li>
         </ul>
-        <a href="join.html" class="ml-4 liquid-morph-element"><span>Sign Up</span></a>
+        <a href="#join" class="ml-4 liquid-morph-element"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>
 
-  <main class="flex-grow">
-    <div class="m-2 p-4 glass">
+  <main class="flex-grow" id="content">
+    <section id="home" class="m-2 p-4 glass">
       <section class="text-center py-3">
         <div class="max-w-4xl mx-auto">
           <h1 class="text-2xl font-bold text-green-700">Welcome to the Financial Modeling Club</h1>
@@ -102,9 +102,10 @@
           </p>
         </div>
       </section>
-    </div>
+    </section>
   </main>
 
   <script src="static/js/scripts.js"></script>
+  <script src="static/js/loadSections.js"></script>
 </body>
 </html>

--- a/docs/sitemap.html
+++ b/docs/sitemap.html
@@ -34,12 +34,12 @@
   <main class="flex-grow py-8 glass m-4">
     <h1 class="text-3xl font-bold mb-4 text-center">Sitemap</h1>
     <ul class="text-center space-y-2">
-      <li><a href="index.html" class="text-green-700 hover:underline">Home</a></li>
-      <li><a href="howwework.html" class="text-green-700 hover:underline">About Us</a></li>
-      <li><a href="speaker.html" class="text-green-700 hover:underline">Speaker of the Week</a></li>
-      <li><a href="leadership.html" class="text-green-700 hover:underline">Leadership</a></li>
-      <li><a href="schedule.html" class="text-green-700 hover:underline">Schedule</a></li>
-      <li><a href="join.html" class="text-green-700 hover:underline">Join</a></li>
+      <li><a href="#home" class="text-green-700 hover:underline">Home</a></li>
+      <li><a href="#howwework" class="text-green-700 hover:underline">About Us</a></li>
+      <li><a href="#speaker" class="text-green-700 hover:underline">Speaker of the Week</a></li>
+      <li><a href="#leadership" class="text-green-700 hover:underline">Leadership</a></li>
+      <li><a href="#schedule" class="text-green-700 hover:underline">Schedule</a></li>
+      <li><a href="#join" class="text-green-700 hover:underline">Join</a></li>
     </ul>
   </main>
 

--- a/docs/static/js/loadSections.js
+++ b/docs/static/js/loadSections.js
@@ -1,0 +1,38 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const pages = [
+    'about.html',
+    'howwework.html',
+    'leadership.html',
+    'schedule.html',
+    'join.html',
+    'speaker.html',
+    'sitemap.html'
+  ];
+  const container = document.getElementById('content');
+  Promise.all(
+    pages.map(page =>
+      fetch(page)
+        .then(resp => resp.text())
+        .then(html => ({ page, html }))
+        .catch(err => {
+          console.error('Failed to load', page, err);
+          return null;
+        })
+    )
+  ).then(results => {
+    results.filter(Boolean).forEach(({ page, html }) => {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(html, 'text/html');
+      const main = doc.querySelector('main');
+      if (main) {
+        const section = document.createElement('section');
+        section.id = page.replace('.html', '');
+        section.innerHTML = main.innerHTML;
+        container.appendChild(section);
+      }
+    });
+    if (window.initFMC) {
+      window.initFMC();
+    }
+  });
+});

--- a/docs/static/js/scripts.js
+++ b/docs/static/js/scripts.js
@@ -1,6 +1,6 @@
-document.addEventListener('DOMContentLoaded', function () {
+function initFMC() {
   const list = document.getElementById('events-list');
-  if (list) {
+  if (list && !list.dataset.loaded) {
     fetch('data/events.json')
       .then(resp => resp.json())
       .then(events => {
@@ -10,17 +10,19 @@ document.addEventListener('DOMContentLoaded', function () {
           li.innerHTML = `<span>${evt.date} - ${evt.title}</span><span class="text-gray-500">${evt.location}</span>`;
           list.appendChild(li);
         });
+        list.dataset.loaded = 'true';
       })
       .catch(() => {
         const li = document.createElement('li');
         li.className = 'border-b py-2';
         li.textContent = 'Unable to load events.';
         list.appendChild(li);
+        list.dataset.loaded = 'true';
       });
   }
 
   const intro = document.getElementById('intro-message');
-  if (intro) {
+  if (intro && !intro.dataset.animated) {
     const text = intro.dataset.message;
     intro.textContent = '';
     setTimeout(() => {
@@ -33,6 +35,7 @@ document.addEventListener('DOMContentLoaded', function () {
         }
       }, 50);
     }, 2000);
+    intro.dataset.animated = 'true';
   }
 
   const PLACEHOLDER = 'https://unsplash.it/500/500';
@@ -48,6 +51,12 @@ document.addEventListener('DOMContentLoaded', function () {
   });
   const instaRows = document.querySelectorAll('.insta-row');
   instaRows.forEach(row => {
-    row.innerHTML += row.innerHTML;
+    if (!row.dataset.duplicated) {
+      row.innerHTML += row.innerHTML;
+      row.dataset.duplicated = 'true';
+    }
   });
-});
+}
+
+document.addEventListener('DOMContentLoaded', initFMC);
+window.initFMC = initFMC;


### PR DESCRIPTION
## Summary
- convert navigation to anchor-based scrolling
- dynamically load individual pages into a single index
- expose scripts initialization for dynamically added sections

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_688d913ff398832d85b6a567c333788b