### PR TITLE
feat: add scroll-triggered typing animation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
       <section class="text-center py-3">
         <div class="max-w-4xl mx-auto">
           <h1 class="text-2xl font-bold text-green-700">Welcome to the Financial Modeling Club</h1>
-          <p id="intro-message" class="mt-2 italic" data-message="Combining advice from professionals in finance with student-led workshops to develop essential financial modeling skills"></p>
+          <p id="intro-message" class="mt-2 italic" data-typing="Combining advice from professionals in finance with student-led workshops to develop essential financial modeling skills"></p>
         </div>
       </section>
 

--- a/docs/static/js/scripts.js
+++ b/docs/static/js/scripts.js
@@ -21,21 +21,28 @@ function initFMC() {
       });
   }
 
-  const intro = document.getElementById('intro-message');
-  if (intro && !intro.dataset.animated) {
-    const text = intro.dataset.message;
-    intro.textContent = '';
-    setTimeout(() => {
-      let i = 0;
-      const interval = setInterval(() => {
-        intro.textContent = text.slice(0, i + 1);
-        i++;
-        if (i === text.length) {
-          clearInterval(interval);
+  const typeTargets = Array.from(document.querySelectorAll('[data-typing]')).filter(el => !el.dataset.animated);
+  if (typeTargets.length) {
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting && !entry.target.dataset.animated) {
+          const el = entry.target;
+          const text = el.dataset.typing;
+          el.textContent = '';
+          let i = 0;
+          const interval = setInterval(() => {
+            el.textContent = text.slice(0, i + 1);
+            i++;
+            if (i === text.length) {
+              clearInterval(interval);
+            }
+          }, 50);
+          el.dataset.animated = 'true';
+          observer.unobserve(el);
         }
-      }, 50);
-    }, 2000);
-    intro.dataset.animated = 'true';
+      });
+    }, { threshold: 0.5 });
+    typeTargets.forEach(el => observer.observe(el));
   }
 
   const PLACEHOLDER = 'https://unsplash.it/500/500';


### PR DESCRIPTION
## Summary
- animate elements with `data-typing` when scrolled into view
- mark home page intro message for scroll-triggered typing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688d94ee76d8832d80b72f4bb0434ec1