### PR TITLE
feat: add scroll-triggered typing animation

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -141,11 +141,23 @@ body {
   margin-top: 1rem;
 }
 
-@keyframes insta-scroll {
-  0% {
-    transform: translateX(0);
+  @keyframes insta-scroll {
+    0% {
+      transform: translateX(0);
+    }
+    100% {
+      transform: translateX(-50%);
+    }
   }
-  100% {
-    transform: translateX(-50%);
+
+/* Typing animation for headings */
+.typing::after {
+  content: '|';
+  animation: blink 0.7s steps(1) infinite;
+}
+
+@keyframes blink {
+  50% {
+    opacity: 0;
   }
 }

--- a/docs/static/js/scripts.js
+++ b/docs/static/js/scripts.js
@@ -91,6 +91,34 @@ function initFMC() {
     });
     document.body.dataset.scrollBound = 'true';
   }
+  initScrollTyping();
+}
+
+function initScrollTyping() {
+  const targets = document.querySelectorAll('h1, h2, h3');
+  const observer = new IntersectionObserver((entries, obs) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        const el = entry.target;
+        if (el.dataset.typingAnimated) return;
+        obs.unobserve(el);
+        const text = el.textContent.trim();
+        el.textContent = '';
+        el.classList.add('typing');
+        let i = 0;
+        const interval = setInterval(() => {
+          el.textContent += text[i];
+          i++;
+          if (i >= text.length) {
+            clearInterval(interval);
+            el.classList.remove('typing');
+            el.dataset.typingAnimated = 'true';
+          }
+        }, 50);
+      }
+    });
+  }, { threshold: 0.6 });
+  targets.forEach(el => observer.observe(el));
 }
 
 document.addEventListener('DOMContentLoaded', initFMC);


### PR DESCRIPTION
## Summary
- add scroll-triggered typing animation for headings using IntersectionObserver
- style animated text with a blinking caret

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688d94ee76d8832d80b72f4bb0434ec1