### PR TITLE
feat: set site background image

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -7,7 +7,10 @@
 }
 body {
   font-family: "Inter", sans-serif;
-
+  background-image: url("../assets/images/grey-black-white-glowing-abstract-gradient-shape-black-grainy-background-minimal-header-cover-poster-design-copy-space_284753-2725.jpg") !important;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
 }
 
 .glass {


### PR DESCRIPTION
## Summary
- use grey/black/white gradient image as global background

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688d94b801ec832d81fd4cf8e8c5d9f1