### PR TITLE
feat: add scroll-triggered typing animation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
       <section class="text-center py-3">
         <div class="max-w-4xl mx-auto">
           <h1 class="text-2xl font-bold text-green-700">Welcome to the Financial Modeling Club</h1>
-          <p id="intro-message" class="mt-2 italic" data-typing="Combining advice from professionals in finance with student-led workshops to develop essential financial modeling skills"></p>
+          <p id="intro-message" class="mt-2 italic">Combining advice from professionals in finance with student-led workshops to develop essential financial modeling skills</p>
         </div>
       </section>
 

--- a/docs/static/js/scripts.js
+++ b/docs/static/js/scripts.js
@@ -21,8 +21,19 @@ function initFMC() {
       });
   }
 
-  const typeTargets = Array.from(document.querySelectorAll('[data-typing]')).filter(el => !el.dataset.animated);
-  if (typeTargets.length) {
+  const candidates = document.querySelectorAll('[data-typing], main h1, main h2, main h3, main h4, main h5, main h6, main p, main li');
+  const typeTargets = Array.from(candidates).filter(el => !el.dataset.animated);
+  typeTargets.forEach(el => {
+    if (!el.dataset.typing) {
+      const text = el.textContent.trim();
+      if (text) {
+        el.dataset.typing = text;
+        el.textContent = '';
+      }
+    }
+  });
+  const toObserve = typeTargets.filter(el => el.dataset.typing);
+  if (toObserve.length) {
     const observer = new IntersectionObserver(entries => {
       entries.forEach(entry => {
         if (entry.isIntersecting && !entry.target.dataset.animated) {
@@ -42,7 +53,7 @@ function initFMC() {
         }
       });
     }, { threshold: 0.5 });
-    typeTargets.forEach(el => observer.observe(el));
+    toObserve.forEach(el => observer.observe(el));
   }
 
   const PLACEHOLDER = 'https://unsplash.it/500/500';


### PR DESCRIPTION
## Summary
- extend script to observe headings, paragraphs, and list items in main content and animate text typing when scrolled into view
- remove data-typing attribute from homepage intro so auto typing applies

## Testing
- `node --check docs/static/js/scripts.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688d96207c38832d858ed328a9ce0429