### PR TITLE
Replace green theme with grayscale palette

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -9,7 +9,7 @@
   <link href="static/css/glass.css" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="flex flex-col min-h-screen bg-gradient-to-br from-green-200 to-green-50">
+<body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none">
     <div class="max-w-7xl mx-auto px-4">
       <div class="flex items-center py-4">

--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -9,7 +9,7 @@
   <link href="static/css/glass.css" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="flex flex-col min-h-screen bg-gradient-to-br from-green-200 to-green-50">
+<body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none">
     <div class="max-w-7xl mx-auto px-4">
       <div class="flex items-center py-4">

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,7 @@
   <link href="static/css/glass.css" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="flex flex-col min-h-screen bg-gradient-to-br from-green-200 to-green-50">
+<body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none">
     <div class="max-w-7xl mx-auto px-4">
       <div class="flex items-center py-4">
@@ -35,7 +35,7 @@
     <section id="home" class="m-2 p-4 glass">
       <section class="text-center py-3">
         <div class="max-w-4xl mx-auto">
-          <h1 class="text-2xl font-bold text-green-700">Welcome to the Financial Modeling Club</h1>
+          <h1 class="text-2xl font-bold text-gray-700">Welcome to the Financial Modeling Club</h1>
           <p id="intro-message" class="mt-2 italic">Combining advice from professionals in finance with student-led workshops to develop essential financial modeling skills</p>
         </div>
       </section>
@@ -98,7 +98,7 @@
             </div>
           </div>
           <p class="mt-3 text-center">
-            <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" class="text-green-700 hover:underline">Follow Us</a>
+            <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" class="text-gray-700 hover:underline">Follow Us</a>
           </p>
         </div>
       </section>

--- a/docs/join.html
+++ b/docs/join.html
@@ -9,7 +9,7 @@
   <link href="static/css/glass.css" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="flex flex-col min-h-screen bg-gradient-to-br from-green-200 to-green-50">
+<body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none">
     <div class="max-w-7xl mx-auto px-4">
       <div class="flex items-center py-4">
@@ -34,9 +34,9 @@
   <main class="flex-grow py-8 glass m-4">
     <section class="max-w-3xl mx-auto px-4">
       <h1 class="text-3xl font-bold mb-4 text-center">Become a Member</h1>
-      <p class="text-center mb-4">We welcome students from all majors and backgrounds. To join the club, simply send an email to <a href="mailto:financialmodel@wm.edu" class="text-green-700 hover:underline">financialmodel@wm.edu</a> with your name and graduation year.</p>
+      <p class="text-center mb-4">We welcome students from all majors and backgrounds. To join the club, simply send an email to <a href="mailto:financialmodel@wm.edu" class="text-gray-700 hover:underline">financialmodel@wm.edu</a> with your name and graduation year.</p>
       <p class="mt-3 text-center">
-        <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" class="text-green-700 hover:underline">Follow us on Instagram →</a>
+        <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" class="text-gray-700 hover:underline">Follow us on Instagram →</a>
       </p>
     </section>
   </main>

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -9,7 +9,7 @@
   <link href="static/css/glass.css" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="flex flex-col min-h-screen bg-gradient-to-br from-green-200 to-green-50">
+<body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none">
     <div class="max-w-7xl mx-auto px-4">
       <div class="flex items-center py-4">

--- a/docs/schedule.html
+++ b/docs/schedule.html
@@ -9,7 +9,7 @@
   <link href="static/css/glass.css" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="flex flex-col min-h-screen bg-gradient-to-br from-green-200 to-green-50">
+<body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none">
     <div class="max-w-7xl mx-auto px-4">
       <div class="flex items-center py-4">

--- a/docs/sitemap.html
+++ b/docs/sitemap.html
@@ -9,7 +9,7 @@
   <link href="static/css/glass.css" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="flex flex-col min-h-screen bg-gradient-to-br from-green-200 to-green-50">
+<body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none">
     <div class="max-w-7xl mx-auto px-4">
       <div class="flex items-center py-4">
@@ -34,12 +34,12 @@
   <main class="flex-grow py-8 glass m-4">
     <h1 class="text-3xl font-bold mb-4 text-center">Sitemap</h1>
     <ul class="text-center space-y-2">
-      <li><a href="#home" class="text-green-700 hover:underline">Home</a></li>
-      <li><a href="#howwework" class="text-green-700 hover:underline">About Us</a></li>
-      <li><a href="#speaker" class="text-green-700 hover:underline">Speaker of the Week</a></li>
-      <li><a href="#leadership" class="text-green-700 hover:underline">Leadership</a></li>
-      <li><a href="#schedule" class="text-green-700 hover:underline">Schedule</a></li>
-      <li><a href="#join" class="text-green-700 hover:underline">Join</a></li>
+      <li><a href="#home" class="text-gray-700 hover:underline">Home</a></li>
+      <li><a href="#howwework" class="text-gray-700 hover:underline">About Us</a></li>
+      <li><a href="#speaker" class="text-gray-700 hover:underline">Speaker of the Week</a></li>
+      <li><a href="#leadership" class="text-gray-700 hover:underline">Leadership</a></li>
+      <li><a href="#schedule" class="text-gray-700 hover:underline">Schedule</a></li>
+      <li><a href="#join" class="text-gray-700 hover:underline">Join</a></li>
     </ul>
   </main>
 

--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -9,7 +9,7 @@
   <link href="static/css/glass.css" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="flex flex-col min-h-screen bg-gradient-to-br from-green-200 to-green-50">
+<body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none">
     <div class="max-w-7xl mx-auto px-4">
       <div class="flex items-center py-4">

--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -2,7 +2,7 @@
 :root {
   --openai-black: #000000;
   --openai-white: #FFFFFF;
-  --chatgpt-green: #00A67E;
+  --accent-gray: #808080;
 
 }
 body {
@@ -31,7 +31,7 @@ body {
 }
 
 .liquid-morph-element {
-  background: var(--chatgpt-green);
+  background: var(--accent-gray);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -57,9 +57,9 @@ body {
   width: 100%;
   height: 100%;
   background: conic-gradient(
-    var(--chatgpt-green) 0deg,
+    var(--accent-gray) 0deg,
     var(--openai-black) 120deg,
-    var(--chatgpt-green) 240deg
+    var(--accent-gray) 240deg
   );
   transition: all 0.6s ease;
   opacity: 0;


### PR DESCRIPTION
## Summary
- switch navigation accent color to neutral gray and use gray gradient across pages
- replace green text and links with gray versions

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688d97843e68832d84344399a962e62a