### PR TITLE
Improve site responsiveness

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -12,21 +12,21 @@
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="flex items-center py-4">
+      <div class="flex flex-col md:flex-row md:items-center py-4">
         <a href="index.html" class="flex items-center">
-          <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
+          <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-16 w-auto md:h-24">
           <div class="ml-2">
-            <span class="block text-3xl">FMCWM</span>
-            <span class="block text-sm">Financial Modeling Club at William & Mary</span>
+            <span class="block text-2xl md:text-3xl">FMCWM</span>
+            <span class="block text-xs md:text-sm">Financial Modeling Club at William & Mary</span>
           </div>
         </a>
-        <ul class="liquid-morph-container flex space-x-4 justify-center flex-1">
+        <ul class="liquid-morph-container mt-4 md:mt-0 flex flex-col md:flex-row justify-center md:flex-1">
           <li><a href="index.html" class="liquid-morph-element"><span>Home</span></a></li>
           <li><a href="howwework.html" class="liquid-morph-element"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="liquid-morph-element"><span>Our Team</span></a></li>
           <li><a href="schedule.html" class="liquid-morph-element"><span>Schedule</span></a></li>
         </ul>
-        <a href="join.html" class="ml-4 liquid-morph-element"><span>Sign Up</span></a>
+        <a href="join.html" class="mt-4 md:mt-0 md:ml-4 liquid-morph-element"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -12,21 +12,21 @@
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="flex items-center py-4">
+      <div class="flex flex-col md:flex-row md:items-center py-4">
         <a href="index.html" class="flex items-center">
-          <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
+          <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-16 w-auto md:h-24">
           <div class="ml-2">
-            <span class="block text-3xl">FMCWM</span>
-            <span class="block text-sm">Financial Modeling Club at William & Mary</span>
+            <span class="block text-2xl md:text-3xl">FMCWM</span>
+            <span class="block text-xs md:text-sm">Financial Modeling Club at William & Mary</span>
           </div>
         </a>
-        <ul class="liquid-morph-container flex space-x-4 justify-center flex-1">
+        <ul class="liquid-morph-container mt-4 md:mt-0 flex flex-col md:flex-row justify-center md:flex-1">
           <li><a href="index.html" class="liquid-morph-element"><span>Home</span></a></li>
           <li><a href="howwework.html" class="liquid-morph-element"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="liquid-morph-element"><span>Our Team</span></a></li>
           <li><a href="schedule.html" class="liquid-morph-element"><span>Schedule</span></a></li>
         </ul>
-        <a href="join.html" class="ml-4 liquid-morph-element"><span>Sign Up</span></a>
+        <a href="join.html" class="mt-4 md:mt-0 md:ml-4 liquid-morph-element"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,21 +12,21 @@
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="flex items-center py-4">
+      <div class="flex flex-col md:flex-row md:items-center py-4">
         <a href="#home" class="flex items-center">
-          <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
+          <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-16 w-auto md:h-24">
           <div class="ml-2">
-            <span class="block text-3xl">FMCWM</span>
-            <span class="block text-sm">Financial Modeling Club at William & Mary</span>
+            <span class="block text-2xl md:text-3xl">FMCWM</span>
+            <span class="block text-xs md:text-sm">Financial Modeling Club at William & Mary</span>
           </div>
         </a>
-        <ul class="liquid-morph-container flex space-x-4 justify-center flex-1">
+        <ul class="liquid-morph-container mt-4 md:mt-0 flex flex-col md:flex-row justify-center md:flex-1">
           <li><a href="#home" class="liquid-morph-element"><span>Home</span></a></li>
           <li><a href="#howwework" class="liquid-morph-element"><span>Meetings</span></a></li>
           <li><a href="#leadership" class="liquid-morph-element"><span>Our Team</span></a></li>
           <li><a href="#schedule" class="liquid-morph-element"><span>Schedule</span></a></li>
         </ul>
-        <a href="#join" class="ml-4 liquid-morph-element"><span>Sign Up</span></a>
+        <a href="#join" class="mt-4 md:mt-0 md:ml-4 liquid-morph-element"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/join.html
+++ b/docs/join.html
@@ -12,21 +12,21 @@
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="flex items-center py-4">
+      <div class="flex flex-col md:flex-row md:items-center py-4">
         <a href="index.html" class="flex items-center">
-          <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
+          <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-16 w-auto md:h-24">
           <div class="ml-2">
-            <span class="block text-3xl">FMCWM</span>
-            <span class="block text-sm">Financial Modeling Club at William & Mary</span>
+            <span class="block text-2xl md:text-3xl">FMCWM</span>
+            <span class="block text-xs md:text-sm">Financial Modeling Club at William & Mary</span>
           </div>
         </a>
-        <ul class="liquid-morph-container flex space-x-4 justify-center flex-1">
+        <ul class="liquid-morph-container mt-4 md:mt-0 flex flex-col md:flex-row justify-center md:flex-1">
           <li><a href="index.html" class="liquid-morph-element"><span>Home</span></a></li>
           <li><a href="howwework.html" class="liquid-morph-element"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="liquid-morph-element"><span>Our Team</span></a></li>
           <li><a href="schedule.html" class="liquid-morph-element"><span>Schedule</span></a></li>
         </ul>
-        <a href="join.html" class="ml-4 liquid-morph-element"><span>Sign Up</span></a>
+        <a href="join.html" class="mt-4 md:mt-0 md:ml-4 liquid-morph-element"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -12,21 +12,21 @@
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="flex items-center py-4">
+      <div class="flex flex-col md:flex-row md:items-center py-4">
         <a href="index.html" class="flex items-center">
-          <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
+          <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-16 w-auto md:h-24">
           <div class="ml-2">
-            <span class="block text-3xl">FMCWM</span>
-            <span class="block text-sm">Financial Modeling Club at William & Mary</span>
+            <span class="block text-2xl md:text-3xl">FMCWM</span>
+            <span class="block text-xs md:text-sm">Financial Modeling Club at William & Mary</span>
           </div>
         </a>
-        <ul class="liquid-morph-container flex space-x-4 justify-center flex-1">
+        <ul class="liquid-morph-container mt-4 md:mt-0 flex flex-col md:flex-row justify-center md:flex-1">
           <li><a href="index.html" class="liquid-morph-element"><span>Home</span></a></li>
           <li><a href="howwework.html" class="liquid-morph-element"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="liquid-morph-element"><span>Our Team</span></a></li>
           <li><a href="schedule.html" class="liquid-morph-element"><span>Schedule</span></a></li>
         </ul>
-        <a href="join.html" class="ml-4 liquid-morph-element"><span>Sign Up</span></a>
+        <a href="join.html" class="mt-4 md:mt-0 md:ml-4 liquid-morph-element"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/schedule.html
+++ b/docs/schedule.html
@@ -12,21 +12,21 @@
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="flex items-center py-4">
+      <div class="flex flex-col md:flex-row md:items-center py-4">
         <a href="index.html" class="flex items-center">
-          <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
+          <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-16 w-auto md:h-24">
           <div class="ml-2">
-            <span class="block text-3xl">FMCWM</span>
-            <span class="block text-sm">Financial Modeling Club at William & Mary</span>
+            <span class="block text-2xl md:text-3xl">FMCWM</span>
+            <span class="block text-xs md:text-sm">Financial Modeling Club at William & Mary</span>
           </div>
         </a>
-        <ul class="liquid-morph-container flex space-x-4 justify-center flex-1">
+        <ul class="liquid-morph-container mt-4 md:mt-0 flex flex-col md:flex-row justify-center md:flex-1">
           <li><a href="index.html" class="liquid-morph-element"><span>Home</span></a></li>
           <li><a href="howwework.html" class="liquid-morph-element"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="liquid-morph-element"><span>Our Team</span></a></li>
           <li><a href="schedule.html" class="liquid-morph-element"><span>Schedule</span></a></li>
         </ul>
-        <a href="join.html" class="ml-4 liquid-morph-element"><span>Sign Up</span></a>
+        <a href="join.html" class="mt-4 md:mt-0 md:ml-4 liquid-morph-element"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/sitemap.html
+++ b/docs/sitemap.html
@@ -12,21 +12,21 @@
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="flex items-center py-4">
+      <div class="flex flex-col md:flex-row md:items-center py-4">
         <a href="index.html" class="flex items-center">
-          <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
+          <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-16 w-auto md:h-24">
           <div class="ml-2">
-            <span class="block text-3xl">FMCWM</span>
-            <span class="block text-sm">Financial Modeling Club at William & Mary</span>
+            <span class="block text-2xl md:text-3xl">FMCWM</span>
+            <span class="block text-xs md:text-sm">Financial Modeling Club at William & Mary</span>
           </div>
         </a>
-        <ul class="liquid-morph-container flex space-x-4 justify-center flex-1">
+        <ul class="liquid-morph-container mt-4 md:mt-0 flex flex-col md:flex-row justify-center md:flex-1">
           <li><a href="index.html" class="liquid-morph-element"><span>Home</span></a></li>
           <li><a href="howwework.html" class="liquid-morph-element"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="liquid-morph-element"><span>Our Team</span></a></li>
           <li><a href="schedule.html" class="liquid-morph-element"><span>Schedule</span></a></li>
         </ul>
-        <a href="join.html" class="ml-4 liquid-morph-element"><span>Sign Up</span></a>
+        <a href="join.html" class="mt-4 md:mt-0 md:ml-4 liquid-morph-element"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -12,21 +12,21 @@
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="flex items-center py-4">
+      <div class="flex flex-col md:flex-row md:items-center py-4">
         <a href="index.html" class="flex items-center">
-          <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
+          <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-16 w-auto md:h-24">
           <div class="ml-2">
-            <span class="block text-3xl">FMCWM</span>
-            <span class="block text-sm">Financial Modeling Club at William & Mary</span>
+            <span class="block text-2xl md:text-3xl">FMCWM</span>
+            <span class="block text-xs md:text-sm">Financial Modeling Club at William & Mary</span>
           </div>
         </a>
-        <ul class="liquid-morph-container flex space-x-4 justify-center flex-1">
+        <ul class="liquid-morph-container mt-4 md:mt-0 flex flex-col md:flex-row justify-center md:flex-1">
           <li><a href="index.html" class="liquid-morph-element"><span>Home</span></a></li>
           <li><a href="howwework.html" class="liquid-morph-element"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="liquid-morph-element"><span>Our Team</span></a></li>
           <li><a href="schedule.html" class="liquid-morph-element"><span>Schedule</span></a></li>
         </ul>
-        <a href="join.html" class="ml-4 liquid-morph-element"><span>Sign Up</span></a>
+        <a href="join.html" class="mt-4 md:mt-0 md:ml-4 liquid-morph-element"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -13,6 +13,11 @@ body {
   background-attachment: fixed;
 }
 
+img {
+  max-width: 100%;
+  height: auto;
+}
+
 .glass {
   background: rgba(255, 255, 255, 0.2);
   border-radius: 1rem;
@@ -162,5 +167,15 @@ body {
 @keyframes blink {
   50% {
     opacity: 0;
+  }
+}
+
+@media (max-width: 640px) {
+  .card {
+    width: 100%;
+    height: auto;
+  }
+  .card-inner {
+    height: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- Adjust navigation markup to stack vertically on small screens while keeping desktop layout
- Add global responsive image rules and mobile-friendly card sizing

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_688d990a2aa4832db7ed7b16a1167682