### PR TITLE
Remove section breaks when loading page fragments

### DIFF
--- a/docs/static/js/loadSections.js
+++ b/docs/static/js/loadSections.js
@@ -25,10 +25,14 @@ document.addEventListener('DOMContentLoaded', () => {
       const doc = parser.parseFromString(html, 'text/html');
       const main = doc.querySelector('main');
       if (main) {
-        const section = document.createElement('section');
-        section.id = page.replace('.html', '');
-        section.innerHTML = main.innerHTML;
-        container.appendChild(section);
+        const fragment = document.createRange().createContextualFragment(
+          main.innerHTML.trim()
+        );
+        const firstElement = fragment.firstElementChild;
+        if (firstElement) {
+          firstElement.id = page.replace('.html', '');
+        }
+        container.appendChild(fragment);
       }
     });
     if (window.initFMC) {


### PR DESCRIPTION
## Summary
- Smooth out combined page rendering by inserting each fetched section directly into the main container
- Trim whitespace and retain anchors to keep navigation working while eliminating gaps between sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688ffa83304c832d8d0cee8171e4688d