### PR TITLE
Adjust Instagram gallery to show four images

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -47,53 +47,53 @@
           <h2 class="text-xl font-bold mb-4 text-center">Latest on Instagram</h2>
           <div class="insta-marquee">
             <div class="insta-row insta-row-fast">
-              <div class="insta-item glass flex-none w-full">
+              <div class="insta-item glass flex-none w-1/4">
                 <img src="https://unsplash.it/800/400" alt="Workshop attendees collaborating" class="h-32 w-full object-cover">
                 <small class="block text-center mt-1">Mar 12, 2025 • Modeling Workshop</small>
               </div>
-              <div class="insta-item glass flex-none w-full">
+              <div class="insta-item glass flex-none w-1/4">
                 <img src="https://unsplash.it/800/400" alt="Guest speaker presenting" class="h-32 w-full object-cover">
                 <small class="block text-center mt-1">Feb 27, 2025 • Guest Speaker</small>
               </div>
-              <div class="insta-item glass flex-none w-full">
+              <div class="insta-item glass flex-none w-1/4">
                 <img src="https://unsplash.it/800/400" alt="Networking social event" class="h-32 w-full object-cover">
                 <small class="block text-center mt-1">Jan 18, 2025 • Networking Social</small>
               </div>
-              <div class="insta-item glass flex-none w-full">
+              <div class="insta-item glass flex-none w-1/4">
                 <img src="https://unsplash.it/800/400" alt="Team building workshop" class="h-32 w-full object-cover">
                 <small class="block text-center mt-1">Dec 02, 2024 • Team Workshop</small>
               </div>
-              <div class="insta-item glass flex-none w-full">
+              <div class="insta-item glass flex-none w-1/4">
                 <img src="https://unsplash.it/800/400" alt="Case competition" class="h-32 w-full object-cover">
                 <small class="block text-center mt-1">Nov 20, 2024 • Case Competition</small>
               </div>
-              <div class="insta-item glass flex-none w-full">
+              <div class="insta-item glass flex-none w-1/4">
                 <img src="https://unsplash.it/800/400" alt="Holiday social" class="h-32 w-full object-cover">
                 <small class="block text-center mt-1">Oct 15, 2024 • Holiday Social</small>
               </div>
             </div>
             <div class="insta-row insta-row-slow">
-              <div class="insta-item glass flex-none w-full">
+              <div class="insta-item glass flex-none w-1/4">
                 <img src="https://unsplash.it/800/400" alt="Workshop attendees collaborating" class="h-32 w-full object-cover">
                 <small class="block text-center mt-1">Mar 12, 2025 • Modeling Workshop</small>
               </div>
-              <div class="insta-item glass flex-none w-full">
+              <div class="insta-item glass flex-none w-1/4">
                 <img src="https://unsplash.it/800/400" alt="Guest speaker presenting" class="h-32 w-full object-cover">
                 <small class="block text-center mt-1">Feb 27, 2025 • Guest Speaker</small>
               </div>
-              <div class="insta-item glass flex-none w-full">
+              <div class="insta-item glass flex-none w-1/4">
                 <img src="https://unsplash.it/800/400" alt="Networking social event" class="h-32 w-full object-cover">
                 <small class="block text-center mt-1">Jan 18, 2025 • Networking Social</small>
               </div>
-              <div class="insta-item glass flex-none w-full">
+              <div class="insta-item glass flex-none w-1/4">
                 <img src="https://unsplash.it/800/400" alt="Team building workshop" class="h-32 w-full object-cover">
                 <small class="block text-center mt-1">Dec 02, 2024 • Team Workshop</small>
               </div>
-              <div class="insta-item glass flex-none w-full">
+              <div class="insta-item glass flex-none w-1/4">
                 <img src="https://unsplash.it/800/400" alt="Case competition" class="h-32 w-full object-cover">
                 <small class="block text-center mt-1">Nov 20, 2024 • Case Competition</small>
               </div>
-              <div class="insta-item glass flex-none w-full">
+              <div class="insta-item glass flex-none w-1/4">
                 <img src="https://unsplash.it/800/400" alt="Holiday social" class="h-32 w-full object-cover">
                 <small class="block text-center mt-1">Oct 15, 2024 • Holiday Social</small>
               </div>


### PR DESCRIPTION
## Summary
- Display four Instagram pictures at a time by shrinking each gallery item to one quarter width

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689005602658832d808ac4a76edec085