### PR TITLE
Use fast fade-in text animation

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -159,16 +159,11 @@ nav {
     }
   }
 
-/* Typing animation for headings */
-.typing::after {
-  content: '|';
-  animation: blink 0.7s steps(1) infinite;
-}
-
-@keyframes blink {
-  50% {
-    opacity: 0;
-  }
+/* Fade typing characters */
+.fade-char {
+  opacity: 0;
+  display: inline-block;
+  transition: opacity 0.2s ease-in;
 }
 
 /* Shimmer effect for logo */

--- a/docs/static/js/scripts.js
+++ b/docs/static/js/scripts.js
@@ -39,15 +39,7 @@ function initFMC() {
         if (entry.isIntersecting && !entry.target.dataset.animated) {
           const el = entry.target;
           const text = el.dataset.typing;
-          el.textContent = '';
-          let i = 0;
-          const interval = setInterval(() => {
-            el.textContent = text.slice(0, i + 1);
-            i++;
-            if (i === text.length) {
-              clearInterval(interval);
-            }
-          }, 50);
+          fadeType(el, text, 15);
           el.dataset.animated = 'true';
           observer.unobserve(el);
         }
@@ -109,34 +101,23 @@ function initFMC() {
     });
     document.body.dataset.scrollBound = 'true';
   }
-  initScrollTyping();
 }
 
-function initScrollTyping() {
-  const targets = document.querySelectorAll('h1, h2, h3');
-  const observer = new IntersectionObserver((entries, obs) => {
-    entries.forEach(entry => {
-      if (entry.isIntersecting) {
-        const el = entry.target;
-        if (el.dataset.typingAnimated) return;
-        obs.unobserve(el);
-        const text = el.textContent.trim();
-        el.textContent = '';
-        el.classList.add('typing');
-        let i = 0;
-        const interval = setInterval(() => {
-          el.textContent += text[i];
-          i++;
-          if (i >= text.length) {
-            clearInterval(interval);
-            el.classList.remove('typing');
-            el.dataset.typingAnimated = 'true';
-          }
-        }, 50);
-      }
+function fadeType(el, text, speed) {
+  el.textContent = '';
+  text.split('').forEach((char, idx) => {
+    const span = document.createElement('span');
+    span.className = 'fade-char';
+    span.textContent = char;
+    span.style.transitionDelay = `${idx * speed}ms`;
+    span.style.whiteSpace = 'pre';
+    el.appendChild(span);
+  });
+  requestAnimationFrame(() => {
+    el.querySelectorAll('.fade-char').forEach(span => {
+      span.style.opacity = '1';
     });
-  }, { threshold: 0.6 });
-  targets.forEach(el => observer.observe(el));
+  });
 }
 
 document.addEventListener('DOMContentLoaded', initFMC);


### PR DESCRIPTION
## Summary
- Replace interval-based typing animation with `fadeType` for faster fade-in text
- Add `.fade-char` styles to support smooth left-to-right fade-in

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689004df8138832db387e51ff49dceb8