### PR TITLE
Increase Instagram feed image height

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -48,53 +48,53 @@
           <div class="insta-marquee">
             <div class="insta-row insta-row-fast">
               <div class="insta-item glass flex-none w-1/4">
-                <img src="https://unsplash.it/800/400" alt="Workshop attendees collaborating" class="h-32 w-full object-cover">
+                <img src="https://unsplash.it/800/400" alt="Workshop attendees collaborating" class="h-48 w-full object-cover">
                 <small class="block text-center mt-1">Mar 12, 2025 • Modeling Workshop</small>
               </div>
               <div class="insta-item glass flex-none w-1/4">
-                <img src="https://unsplash.it/800/400" alt="Guest speaker presenting" class="h-32 w-full object-cover">
+                <img src="https://unsplash.it/800/400" alt="Guest speaker presenting" class="h-48 w-full object-cover">
                 <small class="block text-center mt-1">Feb 27, 2025 • Guest Speaker</small>
               </div>
               <div class="insta-item glass flex-none w-1/4">
-                <img src="https://unsplash.it/800/400" alt="Networking social event" class="h-32 w-full object-cover">
+                <img src="https://unsplash.it/800/400" alt="Networking social event" class="h-48 w-full object-cover">
                 <small class="block text-center mt-1">Jan 18, 2025 • Networking Social</small>
               </div>
               <div class="insta-item glass flex-none w-1/4">
-                <img src="https://unsplash.it/800/400" alt="Team building workshop" class="h-32 w-full object-cover">
+                <img src="https://unsplash.it/800/400" alt="Team building workshop" class="h-48 w-full object-cover">
                 <small class="block text-center mt-1">Dec 02, 2024 • Team Workshop</small>
               </div>
               <div class="insta-item glass flex-none w-1/4">
-                <img src="https://unsplash.it/800/400" alt="Case competition" class="h-32 w-full object-cover">
+                <img src="https://unsplash.it/800/400" alt="Case competition" class="h-48 w-full object-cover">
                 <small class="block text-center mt-1">Nov 20, 2024 • Case Competition</small>
               </div>
               <div class="insta-item glass flex-none w-1/4">
-                <img src="https://unsplash.it/800/400" alt="Holiday social" class="h-32 w-full object-cover">
+                <img src="https://unsplash.it/800/400" alt="Holiday social" class="h-48 w-full object-cover">
                 <small class="block text-center mt-1">Oct 15, 2024 • Holiday Social</small>
               </div>
             </div>
             <div class="insta-row insta-row-slow">
               <div class="insta-item glass flex-none w-1/4">
-                <img src="https://unsplash.it/800/400" alt="Workshop attendees collaborating" class="h-32 w-full object-cover">
+                <img src="https://unsplash.it/800/400" alt="Workshop attendees collaborating" class="h-48 w-full object-cover">
                 <small class="block text-center mt-1">Mar 12, 2025 • Modeling Workshop</small>
               </div>
               <div class="insta-item glass flex-none w-1/4">
-                <img src="https://unsplash.it/800/400" alt="Guest speaker presenting" class="h-32 w-full object-cover">
+                <img src="https://unsplash.it/800/400" alt="Guest speaker presenting" class="h-48 w-full object-cover">
                 <small class="block text-center mt-1">Feb 27, 2025 • Guest Speaker</small>
               </div>
               <div class="insta-item glass flex-none w-1/4">
-                <img src="https://unsplash.it/800/400" alt="Networking social event" class="h-32 w-full object-cover">
+                <img src="https://unsplash.it/800/400" alt="Networking social event" class="h-48 w-full object-cover">
                 <small class="block text-center mt-1">Jan 18, 2025 • Networking Social</small>
               </div>
               <div class="insta-item glass flex-none w-1/4">
-                <img src="https://unsplash.it/800/400" alt="Team building workshop" class="h-32 w-full object-cover">
+                <img src="https://unsplash.it/800/400" alt="Team building workshop" class="h-48 w-full object-cover">
                 <small class="block text-center mt-1">Dec 02, 2024 • Team Workshop</small>
               </div>
               <div class="insta-item glass flex-none w-1/4">
-                <img src="https://unsplash.it/800/400" alt="Case competition" class="h-32 w-full object-cover">
+                <img src="https://unsplash.it/800/400" alt="Case competition" class="h-48 w-full object-cover">
                 <small class="block text-center mt-1">Nov 20, 2024 • Case Competition</small>
               </div>
               <div class="insta-item glass flex-none w-1/4">
-                <img src="https://unsplash.it/800/400" alt="Holiday social" class="h-32 w-full object-cover">
+                <img src="https://unsplash.it/800/400" alt="Holiday social" class="h-48 w-full object-cover">
                 <small class="block text-center mt-1">Oct 15, 2024 • Holiday Social</small>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- enlarge Instagram feed images on the home page for a taller display

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6890080a7f90832d899f3b087f00b956