### PR TITLE
Ensure four Instagram images display at once

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -140,6 +140,10 @@ nav {
   width: max-content;
 }
 
+.insta-item {
+  flex: 0 0 25%;
+}
+
 .insta-row-fast {
   animation: insta-scroll 20s linear infinite;
 }


### PR DESCRIPTION
## Summary
- Set Instagram marquee items to a fixed flex basis so four photos show at the same time

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68900a1e3efc832d94488e004c951e7e