### PR TITLE
Increase base font size for default zoom

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -5,6 +5,9 @@
   --accent-gray: #808080;
 
 }
+html {
+  font-size: 125%;
+}
 body {
   font-family: "Inter", sans-serif;
   background-color: var(--openai-black) !important;


### PR DESCRIPTION
## Summary
- Bump the root font size to 125% so the site at 100% browser zoom matches the former 125% view

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68900ca6e0f0832d94f1cbccc5bc0054