### PR TITLE
feat: add glassmorphic styling to person cards

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -123,11 +123,11 @@ nav {
   justify-content: center;
   border-radius: 0;
   text-align: center;
-  background: var(--openai-black);
-  border: none;
-  backdrop-filter: none;
-  -webkit-backdrop-filter: none;
-  box-shadow: none;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
 }
 
 .card-back {


### PR DESCRIPTION
## Summary
- add glassmorphic backdrop, border, and blur to flip cards used for people

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689019b377f8832d8e29279fe494a844