### PR TITLE
Center nav items and reduce size

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -22,13 +22,13 @@
             <span class="block text-sm">Financial Modeling Club at William & Mary</span>
           </div>
         </a>
-        <ul class="liquid-morph-container flex space-x-4 justify-center flex-1">
+        <ul class="liquid-morph-container flex space-x-4 justify-center mx-auto">
           <li><a href="index.html" class="liquid-morph-element"><span>Home</span></a></li>
           <li><a href="howwework.html" class="liquid-morph-element"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="liquid-morph-element"><span>Our Team</span></a></li>
           <li><a href="schedule.html" class="liquid-morph-element"><span>Schedule</span></a></li>
         </ul>
-        <a href="join.html" class="ml-4 liquid-morph-element"><span>Sign Up</span></a>
+        <a href="join.html" class="ml-auto liquid-morph-element"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -22,13 +22,13 @@
             <span class="block text-sm">Financial Modeling Club at William & Mary</span>
           </div>
         </a>
-        <ul class="liquid-morph-container flex space-x-4 justify-center flex-1">
+        <ul class="liquid-morph-container flex space-x-4 justify-center mx-auto">
           <li><a href="index.html" class="liquid-morph-element"><span>Home</span></a></li>
           <li><a href="howwework.html" class="liquid-morph-element"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="liquid-morph-element"><span>Our Team</span></a></li>
           <li><a href="schedule.html" class="liquid-morph-element"><span>Schedule</span></a></li>
         </ul>
-        <a href="join.html" class="ml-4 liquid-morph-element"><span>Sign Up</span></a>
+        <a href="join.html" class="ml-auto liquid-morph-element"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/index.html
+++ b/docs/index.html
@@ -22,13 +22,13 @@
             <span class="block text-sm">Financial Modeling Club at William & Mary</span>
           </div>
         </a>
-        <ul class="liquid-morph-container flex space-x-4 justify-center flex-1">
+        <ul class="liquid-morph-container flex space-x-4 justify-center mx-auto">
           <li><a href="#home" class="liquid-morph-element"><span>Home</span></a></li>
           <li><a href="#howwework" class="liquid-morph-element"><span>Meetings</span></a></li>
           <li><a href="#leadership" class="liquid-morph-element"><span>Our Team</span></a></li>
           <li><a href="#schedule" class="liquid-morph-element"><span>Schedule</span></a></li>
         </ul>
-        <a href="#join" class="ml-4 liquid-morph-element"><span>Sign Up</span></a>
+        <a href="#join" class="ml-auto liquid-morph-element"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/join.html
+++ b/docs/join.html
@@ -22,13 +22,13 @@
             <span class="block text-sm">Financial Modeling Club at William & Mary</span>
           </div>
         </a>
-        <ul class="liquid-morph-container flex space-x-4 justify-center flex-1">
+        <ul class="liquid-morph-container flex space-x-4 justify-center mx-auto">
           <li><a href="index.html" class="liquid-morph-element"><span>Home</span></a></li>
           <li><a href="howwework.html" class="liquid-morph-element"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="liquid-morph-element"><span>Our Team</span></a></li>
           <li><a href="schedule.html" class="liquid-morph-element"><span>Schedule</span></a></li>
         </ul>
-        <a href="join.html" class="ml-4 liquid-morph-element"><span>Sign Up</span></a>
+        <a href="join.html" class="ml-auto liquid-morph-element"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -22,13 +22,13 @@
             <span class="block text-sm">Financial Modeling Club at William & Mary</span>
           </div>
         </a>
-        <ul class="liquid-morph-container flex space-x-4 justify-center flex-1">
+        <ul class="liquid-morph-container flex space-x-4 justify-center mx-auto">
           <li><a href="index.html" class="liquid-morph-element"><span>Home</span></a></li>
           <li><a href="howwework.html" class="liquid-morph-element"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="liquid-morph-element"><span>Our Team</span></a></li>
           <li><a href="schedule.html" class="liquid-morph-element"><span>Schedule</span></a></li>
         </ul>
-        <a href="join.html" class="ml-4 liquid-morph-element"><span>Sign Up</span></a>
+        <a href="join.html" class="ml-auto liquid-morph-element"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/schedule.html
+++ b/docs/schedule.html
@@ -22,13 +22,13 @@
             <span class="block text-sm">Financial Modeling Club at William & Mary</span>
           </div>
         </a>
-        <ul class="liquid-morph-container flex space-x-4 justify-center flex-1">
+        <ul class="liquid-morph-container flex space-x-4 justify-center mx-auto">
           <li><a href="index.html" class="liquid-morph-element"><span>Home</span></a></li>
           <li><a href="howwework.html" class="liquid-morph-element"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="liquid-morph-element"><span>Our Team</span></a></li>
           <li><a href="schedule.html" class="liquid-morph-element"><span>Schedule</span></a></li>
         </ul>
-        <a href="join.html" class="ml-4 liquid-morph-element"><span>Sign Up</span></a>
+        <a href="join.html" class="ml-auto liquid-morph-element"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/sitemap.html
+++ b/docs/sitemap.html
@@ -22,13 +22,13 @@
             <span class="block text-sm">Financial Modeling Club at William & Mary</span>
           </div>
         </a>
-        <ul class="liquid-morph-container flex space-x-4 justify-center flex-1">
+        <ul class="liquid-morph-container flex space-x-4 justify-center mx-auto">
           <li><a href="index.html" class="liquid-morph-element"><span>Home</span></a></li>
           <li><a href="howwework.html" class="liquid-morph-element"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="liquid-morph-element"><span>Our Team</span></a></li>
           <li><a href="schedule.html" class="liquid-morph-element"><span>Schedule</span></a></li>
         </ul>
-        <a href="join.html" class="ml-4 liquid-morph-element"><span>Sign Up</span></a>
+        <a href="join.html" class="ml-auto liquid-morph-element"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -22,13 +22,13 @@
             <span class="block text-sm">Financial Modeling Club at William & Mary</span>
           </div>
         </a>
-        <ul class="liquid-morph-container flex space-x-4 justify-center flex-1">
+        <ul class="liquid-morph-container flex space-x-4 justify-center mx-auto">
           <li><a href="index.html" class="liquid-morph-element"><span>Home</span></a></li>
           <li><a href="howwework.html" class="liquid-morph-element"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="liquid-morph-element"><span>Our Team</span></a></li>
           <li><a href="schedule.html" class="liquid-morph-element"><span>Schedule</span></a></li>
         </ul>
-        <a href="join.html" class="ml-4 liquid-morph-element"><span>Sign Up</span></a>
+        <a href="join.html" class="ml-auto liquid-morph-element"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -41,7 +41,7 @@ nav {
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 1rem;
+  gap: 0.5rem;
 }
 
 .liquid-morph-element {
@@ -49,7 +49,7 @@ nav {
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 0.5rem 1rem;
+  padding: 0.25rem 0.5rem;
   position: relative;
   border-radius: 50px;
   overflow: hidden;
@@ -58,9 +58,10 @@ nav {
 
 .liquid-morph-element span {
   color: var(--openai-white);
-  font-size: 1rem;
+  font-size: 0.875rem;
   position: relative;
   z-index: 2;
+  text-align: center;
 }
 
 .liquid-morph-element::before {


### PR DESCRIPTION
## Summary
- Center navbar links and move sign-up button to far right
- Shrink navbar item padding and font size for a more compact layout

## Testing
- `npm test` (fails: package.json not found)


------
https://chatgpt.com/codex/tasks/task_b_689019d2b7a0832d9634b3e7d7bd6d63