### PR TITLE
Display six Instagram cards at once

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -47,53 +47,53 @@
           <h2 class="text-xl font-bold mb-4 text-center">Latest on Instagram</h2>
           <div class="insta-marquee">
             <div class="insta-row insta-row-fast">
-              <div class="insta-item glass flex-none w-1/4">
+              <div class="insta-item glass flex-none w-1/6">
                 <img src="https://unsplash.it/800/400" alt="Workshop attendees collaborating" class="h-48 w-full object-cover">
                 <small class="block text-center mt-1">Mar 12, 2025 • Modeling Workshop</small>
               </div>
-              <div class="insta-item glass flex-none w-1/4">
+              <div class="insta-item glass flex-none w-1/6">
                 <img src="https://unsplash.it/800/400" alt="Guest speaker presenting" class="h-48 w-full object-cover">
                 <small class="block text-center mt-1">Feb 27, 2025 • Guest Speaker</small>
               </div>
-              <div class="insta-item glass flex-none w-1/4">
+              <div class="insta-item glass flex-none w-1/6">
                 <img src="https://unsplash.it/800/400" alt="Networking social event" class="h-48 w-full object-cover">
                 <small class="block text-center mt-1">Jan 18, 2025 • Networking Social</small>
               </div>
-              <div class="insta-item glass flex-none w-1/4">
+              <div class="insta-item glass flex-none w-1/6">
                 <img src="https://unsplash.it/800/400" alt="Team building workshop" class="h-48 w-full object-cover">
                 <small class="block text-center mt-1">Dec 02, 2024 • Team Workshop</small>
               </div>
-              <div class="insta-item glass flex-none w-1/4">
+              <div class="insta-item glass flex-none w-1/6">
                 <img src="https://unsplash.it/800/400" alt="Case competition" class="h-48 w-full object-cover">
                 <small class="block text-center mt-1">Nov 20, 2024 • Case Competition</small>
               </div>
-              <div class="insta-item glass flex-none w-1/4">
+              <div class="insta-item glass flex-none w-1/6">
                 <img src="https://unsplash.it/800/400" alt="Holiday social" class="h-48 w-full object-cover">
                 <small class="block text-center mt-1">Oct 15, 2024 • Holiday Social</small>
               </div>
             </div>
             <div class="insta-row insta-row-slow">
-              <div class="insta-item glass flex-none w-1/4">
+              <div class="insta-item glass flex-none w-1/6">
                 <img src="https://unsplash.it/800/400" alt="Workshop attendees collaborating" class="h-48 w-full object-cover">
                 <small class="block text-center mt-1">Mar 12, 2025 • Modeling Workshop</small>
               </div>
-              <div class="insta-item glass flex-none w-1/4">
+              <div class="insta-item glass flex-none w-1/6">
                 <img src="https://unsplash.it/800/400" alt="Guest speaker presenting" class="h-48 w-full object-cover">
                 <small class="block text-center mt-1">Feb 27, 2025 • Guest Speaker</small>
               </div>
-              <div class="insta-item glass flex-none w-1/4">
+              <div class="insta-item glass flex-none w-1/6">
                 <img src="https://unsplash.it/800/400" alt="Networking social event" class="h-48 w-full object-cover">
                 <small class="block text-center mt-1">Jan 18, 2025 • Networking Social</small>
               </div>
-              <div class="insta-item glass flex-none w-1/4">
+              <div class="insta-item glass flex-none w-1/6">
                 <img src="https://unsplash.it/800/400" alt="Team building workshop" class="h-48 w-full object-cover">
                 <small class="block text-center mt-1">Dec 02, 2024 • Team Workshop</small>
               </div>
-              <div class="insta-item glass flex-none w-1/4">
+              <div class="insta-item glass flex-none w-1/6">
                 <img src="https://unsplash.it/800/400" alt="Case competition" class="h-48 w-full object-cover">
                 <small class="block text-center mt-1">Nov 20, 2024 • Case Competition</small>
               </div>
-              <div class="insta-item glass flex-none w-1/4">
+              <div class="insta-item glass flex-none w-1/6">
                 <img src="https://unsplash.it/800/400" alt="Holiday social" class="h-48 w-full object-cover">
                 <small class="block text-center mt-1">Oct 15, 2024 • Holiday Social</small>
               </div>

--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -147,7 +147,7 @@ nav {
 }
 
 .insta-item {
-  flex: 0 0 25%;
+  flex: 0 0 16.6667%;
 }
 
 .insta-row-fast {


### PR DESCRIPTION
## Summary
- Show six Instagram cards in the marquee by shrinking each card's width
- Adjust card flex basis to match new width

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_b_689019ecc1d0832da7b41a5cb375d0b8