### PR TITLE
Make logo shimmer circular

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -196,6 +196,7 @@ nav {
   position: relative;
   display: inline-block;
   overflow: hidden;
+  border-radius: 50%;
 }
 
 .logo-shimmer::after {
@@ -214,6 +215,7 @@ nav {
   transform: skewX(-25deg);
   animation: logo-shimmer 2s infinite;
   pointer-events: none;
+  border-radius: 50%;
 }
 
 @keyframes logo-shimmer {


### PR DESCRIPTION
## Summary
- make logo shimmer circular by adding border-radius to the shimmer container and overlay

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_b_68901a0b74dc832d8259079ef1041df9