### PR TITLE
Speed up text reveal animation

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -163,7 +163,7 @@ nav {
 .fade-char {
   opacity: 0;
   display: inline-block;
-  transition: opacity 0.2s ease-in;
+  transition: opacity 0.1s ease-in;
 }
 
 /* Shimmer effect for logo */

--- a/docs/static/js/scripts.js
+++ b/docs/static/js/scripts.js
@@ -39,7 +39,7 @@ function initFMC() {
         if (entry.isIntersecting && !entry.target.dataset.animated) {
           const el = entry.target;
           const text = el.dataset.typing;
-          fadeType(el, text, 15);
+          fadeType(el, text, 5);
           el.dataset.animated = 'true';
           observer.unobserve(el);
         }


### PR DESCRIPTION
## Summary
- Decrease per-character delay in `fadeType` to accelerate typing effect
- Reduce CSS fade duration to make characters appear quicker

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68900a498d94832d8225e6f6bbaec7d5