### PR TITLE
Slow down nav bar scroll

### DIFF
--- a/docs/static/js/scripts.js
+++ b/docs/static/js/scripts.js
@@ -76,7 +76,7 @@ function initFMC() {
           e.preventDefault();
           const start = window.scrollY;
           const end = target.getBoundingClientRect().top + start;
-          const duration = 600;
+          const duration = 900;
           const startTime = performance.now();
 
           function easeInOutQuad(t) {


### PR DESCRIPTION
## Summary
- Slow nav bar smooth scrolling 50% by increasing duration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689020d72284832da2119229a97f2622