### PR TITLE
Remove FMCWM acronym from navigation

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -18,8 +18,8 @@
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
           <div class="ml-2 hover-jiggle">
-            <span class="block text-3xl">FMCWM</span>
-            <span class="block text-sm">Financial Modeling Club at William & Mary</span>
+            <span class="block text-3xl">Financial Modeling Club</span>
+            <span class="block text-sm">at William & Mary</span>
           </div>
         </a>
         <ul class="liquid-morph-container flex space-x-4 justify-center mx-auto">

--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -18,8 +18,8 @@
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
           <div class="ml-2 hover-jiggle">
-            <span class="block text-3xl">FMCWM</span>
-            <span class="block text-sm">Financial Modeling Club at William & Mary</span>
+            <span class="block text-3xl">Financial Modeling Club</span>
+            <span class="block text-sm">at William & Mary</span>
           </div>
         </a>
         <ul class="liquid-morph-container flex space-x-4 justify-center mx-auto">

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,8 +18,8 @@
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
           <div class="ml-2 hover-jiggle">
-            <span class="block text-3xl">FMCWM</span>
-            <span class="block text-sm">Financial Modeling Club at William & Mary</span>
+            <span class="block text-3xl">Financial Modeling Club</span>
+            <span class="block text-sm">at William & Mary</span>
           </div>
         </a>
         <ul class="liquid-morph-container flex space-x-4 justify-center mx-auto">

--- a/docs/join.html
+++ b/docs/join.html
@@ -18,8 +18,8 @@
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
           <div class="ml-2 hover-jiggle">
-            <span class="block text-3xl">FMCWM</span>
-            <span class="block text-sm">Financial Modeling Club at William & Mary</span>
+            <span class="block text-3xl">Financial Modeling Club</span>
+            <span class="block text-sm">at William & Mary</span>
           </div>
         </a>
         <ul class="liquid-morph-container flex space-x-4 justify-center mx-auto">

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -18,8 +18,8 @@
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
           <div class="ml-2 hover-jiggle">
-            <span class="block text-3xl">FMCWM</span>
-            <span class="block text-sm">Financial Modeling Club at William & Mary</span>
+            <span class="block text-3xl">Financial Modeling Club</span>
+            <span class="block text-sm">at William & Mary</span>
           </div>
         </a>
         <ul class="liquid-morph-container flex space-x-4 justify-center mx-auto">

--- a/docs/schedule.html
+++ b/docs/schedule.html
@@ -18,8 +18,8 @@
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
           <div class="ml-2 hover-jiggle">
-            <span class="block text-3xl">FMCWM</span>
-            <span class="block text-sm">Financial Modeling Club at William & Mary</span>
+            <span class="block text-3xl">Financial Modeling Club</span>
+            <span class="block text-sm">at William & Mary</span>
           </div>
         </a>
         <ul class="liquid-morph-container flex space-x-4 justify-center mx-auto">

--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -18,8 +18,8 @@
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
           <div class="ml-2 hover-jiggle">
-            <span class="block text-3xl">FMCWM</span>
-            <span class="block text-sm">Financial Modeling Club at William & Mary</span>
+            <span class="block text-3xl">Financial Modeling Club</span>
+            <span class="block text-sm">at William & Mary</span>
           </div>
         </a>
         <ul class="liquid-morph-container flex space-x-4 justify-center mx-auto">


### PR DESCRIPTION
## Summary
- Replace `FMCWM` acronym with `Financial Modeling Club` and add `at William & Mary` tagline across site pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689021031024832da04820865168b2cb