### PR TITLE
Slow header and description animations

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -15,8 +15,24 @@ body {
   color: var(--openai-white) !important;
 }
 
+/* Navigation uses default system fonts to keep non-nav text in Inter */
+nav, nav * {
+  font-family: Helvetica, Arial, sans-serif;
+}
+
 body * {
   color: var(--openai-white) !important;
+}
+
+/* Uniform section header sizing to match "Who We Are" */
+main h1,
+main h2,
+main h3,
+main h4,
+main h5,
+main h6 {
+  font-size: 1.875rem !important; /* Tailwind's text-3xl */
+  line-height: 2.25rem !important;
 }
 
 /* Sticky navigation bar */
@@ -174,12 +190,12 @@ nav {
 .fade-char {
   opacity: 0;
   display: inline-block;
-  transition: opacity 0.3s ease-in;
+  transition: opacity 0.9s ease-in;
 }
 
 .fade-in-block {
   opacity: 0;
-  transition: opacity 0.9s ease-in-out;
+  transition: opacity 2.7s ease-in-out;
 }
 
 .fade-in-block.visible {

--- a/docs/static/js/scripts.js
+++ b/docs/static/js/scripts.js
@@ -41,7 +41,7 @@ function initFMC() {
         if (entry.isIntersecting && !entry.target.dataset.animated) {
           const el = entry.target;
           const text = el.dataset.typing;
-          fadeType(el, text, 15);
+          fadeType(el, text, 45);
           el.dataset.animated = 'true';
           observer.unobserve(el);
         }


### PR DESCRIPTION
## Summary
- Slow section heading typing animation and paragraph fade-in for a more deliberate reveal
- Standardize all section headers to match "Who We Are" font size
- Keep navigation in system fonts while using Inter for the rest of the page

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6890231d35ec832da910d420b654f87c