### PR TITLE
Slow nav scroll by 50%

### DIFF
--- a/docs/static/js/scripts.js
+++ b/docs/static/js/scripts.js
@@ -95,7 +95,7 @@ function initFMC() {
           e.preventDefault();
           const start = window.scrollY;
           const end = target.getBoundingClientRect().top + start;
-          const duration = 900;
+          const duration = 1800; // slowed scroll by 50%
           const startTime = performance.now();
 
           function easeInOutQuad(t) {


### PR DESCRIPTION
## Summary
- Slow smooth scroll for in-page navigation links by doubling the animation duration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689024e551f8832daff6fdfa1b07a90d