### PR TITLE
feat: use monospace font for headers

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -33,6 +33,7 @@ main h5,
 main h6 {
   font-size: 1.875rem !important; /* Tailwind's text-3xl */
   line-height: 2.25rem !important;
+  font-family: "Courier New", monospace;
 }
 
 /* Sticky navigation bar */


### PR DESCRIPTION
## Summary
- style all main headers with a monospace font for a keyboard-typed look

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68902677c194832db65cce1e572ba2d7