### PR TITLE
fix: prevent horizontal scrolling

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -7,12 +7,14 @@
 }
 html {
   font-size: 125%;
+  overflow-x: hidden;
 }
 body {
   font-family: "Inter", sans-serif;
   background-color: var(--openai-black) !important;
   background-image: none !important;
   color: var(--openai-white) !important;
+  overflow-x: hidden;
 }
 
 /* Navigation uses default system fonts to keep non-nav text in Inter */


### PR DESCRIPTION
## Summary
- prevent horizontal scrolling by hiding x-overflow on html and body

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689028871c40832dbc4c0c2b925ec179