### PR TITLE
Add typewriter effect for section headers

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -187,13 +187,6 @@ nav {
     }
   }
 
-/* Fade typing characters */
-.fade-char {
-  opacity: 0;
-  display: inline-block;
-  transition: opacity 0.9s ease-in;
-}
-
 .fade-in-block {
   opacity: 0;
   transition: opacity 2.7s ease-in-out;

--- a/docs/static/js/scripts.js
+++ b/docs/static/js/scripts.js
@@ -41,7 +41,7 @@ function initFMC() {
         if (entry.isIntersecting && !entry.target.dataset.animated) {
           const el = entry.target;
           const text = el.dataset.typing;
-          fadeType(el, text, 45);
+          typeText(el, text, 45);
           el.dataset.animated = 'true';
           observer.unobserve(el);
         }
@@ -122,46 +122,24 @@ function initFMC() {
   }
 }
 
-function fadeType(el, text, speed) {
+function typeText(el, text, speed) {
   el.textContent = '';
   const isHeading = /^H[1-6]$/.test(el.tagName);
-  const chars = Array.from(text);
-  if (isHeading) {
-    chars.push('_');
+  let idx = 0;
+
+  function typeNext() {
+    if (idx < text.length) {
+      el.textContent += text[idx++];
+      setTimeout(typeNext, speed);
+    } else if (isHeading) {
+      const cursor = document.createElement('span');
+      cursor.className = 'cursor';
+      cursor.textContent = '_';
+      el.appendChild(cursor);
+    }
   }
 
-  const spans = chars.map((char, idx) => {
-    const span = document.createElement('span');
-    span.className = 'fade-char';
-    if (isHeading && idx === chars.length - 1) {
-      span.classList.add('cursor');
-    }
-    span.textContent = char;
-    span.style.whiteSpace = 'pre';
-    el.appendChild(span);
-    return span;
-  });
-
-  const lines = new Map();
-  spans.forEach(span => {
-    const top = span.offsetTop;
-    if (!lines.has(top)) {
-      lines.set(top, []);
-    }
-    lines.get(top).push(span);
-  });
-
-  lines.forEach(lineSpans => {
-    lineSpans.forEach((span, idx) => {
-      span.style.transitionDelay = `${idx * speed}ms`;
-    });
-  });
-
-  requestAnimationFrame(() => {
-    spans.forEach(span => {
-      span.style.opacity = '1';
-    });
-  });
+  typeNext();
 }
 
 document.addEventListener('DOMContentLoaded', initFMC);


### PR DESCRIPTION
## Summary
- animate header text with a typewriter-style effect instead of fading
- remove unused fade-related styling

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689028f90220832dbc97e2cce4b1aa77