### PR TITLE
Slow section header typing by 50%

### DIFF
--- a/docs/static/js/scripts.js
+++ b/docs/static/js/scripts.js
@@ -41,7 +41,7 @@ function initFMC() {
         if (entry.isIntersecting && !entry.target.dataset.animated) {
           const el = entry.target;
           const text = el.dataset.typing;
-          typeText(el, text, 45);
+          typeText(el, text, 68); // slowed typing by 50%
           el.dataset.animated = 'true';
           observer.unobserve(el);
         }


### PR DESCRIPTION
## Summary
- Slow down section header typing effect by 50% for clearer emphasis

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68902b96643c832dabaf97745ffff664