### PR TITLE
chore: ensure sticky navbar

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -40,6 +40,7 @@ main h6 {
 
 /* Sticky navigation bar */
 nav {
+  position: -webkit-sticky; /* Safari compatibility */
   position: sticky;
   top: 0;
   z-index: 50;


### PR DESCRIPTION
## Summary
- add Safari sticky fallback to keep navbar at top during scroll

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68902cd093a4832db5be7c3846bd8bd1