### PR TITLE
Refactor leadership team cards

### DIFF
--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -41,89 +41,47 @@
       </p>
         <div class="grid gap-6 sm:grid-cols-2 md:grid-cols-3">
           <div class="card">
-            <div class="card-inner">
-              <div class="card-front p-4">
-                <img src="static/assets/images/DSawyer.jpeg" alt="Davis K. Sawyer" class="mx-auto h-40 w-40 object-cover">
-                <p class="mt-2 font-semibold">Davis K. Sawyer</p>
-                <p class="text-sm">President &amp; Founder</p>
-              </div>
-              <div class="card-back p-4">
-                <p class="font-semibold">Davis K. Sawyer</p>
-                <p class="text-sm mb-2">Finance '27</p>
-                <a href="https://www.linkedin.com/in/davis-sawyer-wm2027/" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
-              </div>
-            </div>
+            <img src="static/assets/images/DSawyer.jpeg" alt="Davis K. Sawyer" class="mx-auto h-40 w-40 object-cover">
+            <p class="mt-2 font-semibold text-center">Davis K. Sawyer</p>
+            <p class="text-sm text-center">President &amp; Founder</p>
+            <p class="text-sm text-center mb-2">Finance '27</p>
+            <a href="https://www.linkedin.com/in/davis-sawyer-wm2027/" target="_blank" class="block text-blue-500 text-center mt-2"><i class="fab fa-linkedin fa-lg"></i></a>
           </div>
           <div class="card">
-            <div class="card-inner">
-              <div class="card-front p-4">
-                <img src="static/assets/images/100_0379 (2) - Edited - Edited - Edited.jpg" alt="Jack Aitken" class="mx-auto h-40 w-40 object-cover">
-                <p class="mt-2 font-semibold">Jack W. Aitken</p>
-                <p class="text-sm">VP, Financial Modeling</p>
-              </div>
-              <div class="card-back p-4">
-                <p class="font-semibold">Jack W. Aitken</p>
-                <p class="text-sm mb-2">Computer Science '27</p>
-                <a href="https://www.linkedin.com/in/jack-aitken-b516a5282/" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
-              </div>
-            </div>
+            <img src="static/assets/images/100_0379 (2) - Edited - Edited - Edited.jpg" alt="Jack Aitken" class="mx-auto h-40 w-40 object-cover">
+            <p class="mt-2 font-semibold text-center">Jack W. Aitken</p>
+            <p class="text-sm text-center">VP, Financial Modeling</p>
+            <p class="text-sm text-center mb-2">Computer Science '27</p>
+            <a href="https://www.linkedin.com/in/jack-aitken-b516a5282/" target="_blank" class="block text-blue-500 text-center mt-2"><i class="fab fa-linkedin fa-lg"></i></a>
           </div>
           <div class="card">
-            <div class="card-inner">
-              <div class="card-front p-4">
-                <img src="static/assets/images/IMG_9764 (1) - Edited - Edited.jpg" alt="Daniel R. Butler" class="mx-auto h-40 w-40 object-cover">
-                <p class="mt-2 font-semibold">Daniel R. Butler</p>
-                <p class="text-sm">VP, Operations</p>
-              </div>
-              <div class="card-back p-4">
-                <p class="font-semibold">Daniel R. Butler</p>
-                <p class="text-sm">Applied Math '25</p>
-                <p class="text-sm mb-2">MS Computer Science '27</p>
-                <a href="https://www.linkedin.com/in/daniel-butler-a1ba3a296/" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
-              </div>
-            </div>
+            <img src="static/assets/images/IMG_9764 (1) - Edited - Edited.jpg" alt="Daniel R. Butler" class="mx-auto h-40 w-40 object-cover">
+            <p class="mt-2 font-semibold text-center">Daniel R. Butler</p>
+            <p class="text-sm text-center">VP, Operations</p>
+            <p class="text-sm text-center">Applied Math '25</p>
+            <p class="text-sm text-center mb-2">MS Computer Science '27</p>
+            <a href="https://www.linkedin.com/in/daniel-butler-a1ba3a296/" target="_blank" class="block text-blue-500 text-center mt-2"><i class="fab fa-linkedin fa-lg"></i></a>
           </div>
           <div class="card">
-            <div class="card-inner">
-              <div class="card-front p-4">
-                <img src="static/assets/images/IMG_3556 - Edited.jpg" alt="Tom Chesnut" class="mx-auto h-40 w-40 object-cover">
-                <p class="mt-2 font-semibold">Tom G. Chesnut</p>
-                <p class="text-sm">VP, Mentorship</p>
-              </div>
-              <div class="card-back p-4">
-                <p class="font-semibold">Tom G. Chesnut</p>
-                <p class="text-sm mb-2">History &amp; Religion '27</p>
-                <a href="https://www.linkedin.com/in/tom-chesnut-2593a329b/" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
-              </div>
-            </div>
+            <img src="static/assets/images/IMG_3556 - Edited.jpg" alt="Tom Chesnut" class="mx-auto h-40 w-40 object-cover">
+            <p class="mt-2 font-semibold text-center">Tom G. Chesnut</p>
+            <p class="text-sm text-center">VP, Mentorship</p>
+            <p class="text-sm text-center mb-2">History &amp; Religion '27</p>
+            <a href="https://www.linkedin.com/in/tom-chesnut-2593a329b/" target="_blank" class="block text-blue-500 text-center mt-2"><i class="fab fa-linkedin fa-lg"></i></a>
           </div>
           <div class="card">
-            <div class="card-inner">
-              <div class="card-front p-4">
-                <img src="static/assets/images/Luke_Archey.jpeg" alt="Luke X. Archey" class="mx-auto h-40 w-40 object-cover">
-                <p class="mt-2 font-semibold">Luke X. Archey</p>
-                <p class="text-sm">VP, Marketing</p>
-              </div>
-              <div class="card-back p-4">
-                <p class="font-semibold">Luke X. Archey</p>
-                <p class="text-sm mb-2">Economics '26</p>
-                <a href="https://www.linkedin.com/in/luke-archey-a23668263/" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
-              </div>
-            </div>
+            <img src="static/assets/images/Luke_Archey.jpeg" alt="Luke X. Archey" class="mx-auto h-40 w-40 object-cover">
+            <p class="mt-2 font-semibold text-center">Luke X. Archey</p>
+            <p class="text-sm text-center">VP, Marketing</p>
+            <p class="text-sm text-center mb-2">Economics '26</p>
+            <a href="https://www.linkedin.com/in/luke-archey-a23668263/" target="_blank" class="block text-blue-500 text-center mt-2"><i class="fab fa-linkedin fa-lg"></i></a>
           </div>
           <div class="card">
-            <div class="card-inner">
-              <div class="card-front p-4">
-                <img src="static/assets/images/IMG_9763 - Edited.jpg" alt="Ben L. Michaud" class="mx-auto h-40 w-40 object-cover">
-                <p class="mt-2 font-semibold">Ben L. Michaud</p>
-                <p class="text-sm">VP, Finance</p>
-              </div>
-              <div class="card-back p-4">
-                <p class="font-semibold">Ben L. Michaud</p>
-                <p class="text-sm mb-2">Economics '26</p>
-                <a href="https://www.linkedin.com/in/benmichaud1/" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
-              </div>
-            </div>
+            <img src="static/assets/images/IMG_9763 - Edited.jpg" alt="Ben L. Michaud" class="mx-auto h-40 w-40 object-cover">
+            <p class="mt-2 font-semibold text-center">Ben L. Michaud</p>
+            <p class="text-sm text-center">VP, Finance</p>
+            <p class="text-sm text-center mb-2">Economics '26</p>
+            <a href="https://www.linkedin.com/in/benmichaud1/" target="_blank" class="block text-blue-500 text-center mt-2"><i class="fab fa-linkedin fa-lg"></i></a>
           </div>
         </div>
     </section>
@@ -135,46 +93,25 @@
       </p>
         <div class="grid gap-8 sm:grid-cols-2 md:grid-cols-3">
           <div class="card">
-            <div class="card-inner">
-              <div class="card-front p-4">
-                <img src="static/assets/images/297db81b-4a12-4c0b-b739-5fcb7aa892cc.jpg" alt="Audrey P. Sims" class="mx-auto h-40 w-40 object-cover">
-                <p class="mt-2 font-semibold">Audrey P. Sims</p>
-                <p class="text-sm">Director, Marketing</p>
-              </div>
-              <div class="card-back p-4">
-                <p class="font-semibold">Audrey P. Sims</p>
-                <p class="text-sm mb-2">Finance '27</p>
-                <a href="https://www.linkedin.com/in/audreysims" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
-              </div>
-            </div>
+            <img src="static/assets/images/297db81b-4a12-4c0b-b739-5fcb7aa892cc.jpg" alt="Audrey P. Sims" class="mx-auto h-40 w-40 object-cover">
+            <p class="mt-2 font-semibold text-center">Audrey P. Sims</p>
+            <p class="text-sm text-center">Director, Marketing</p>
+            <p class="text-sm text-center mb-2">Finance '27</p>
+            <a href="https://www.linkedin.com/in/audreysims" target="_blank" class="block text-blue-500 text-center mt-2"><i class="fab fa-linkedin fa-lg"></i></a>
           </div>
           <div class="card">
-            <div class="card-inner">
-              <div class="card-front p-4">
-                <img src="static/assets/images/TJander.jpeg" alt="Tristan C. Jander" class="mx-auto h-40 w-40 object-cover">
-                <p class="mt-2 font-semibold">Tristan C. Jander</p>
-                <p class="text-sm">Director, Finance</p>
-              </div>
-              <div class="card-back p-4">
-                <p class="font-semibold">Tristan C. Jander</p>
-                <p class="text-sm mb-2">Accounting '27</p>
-                <a href="https://www.linkedin.com/in/tristan-jander/" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
-              </div>
-            </div>
+            <img src="static/assets/images/TJander.jpeg" alt="Tristan C. Jander" class="mx-auto h-40 w-40 object-cover">
+            <p class="mt-2 font-semibold text-center">Tristan C. Jander</p>
+            <p class="text-sm text-center">Director, Finance</p>
+            <p class="text-sm text-center mb-2">Accounting '27</p>
+            <a href="https://www.linkedin.com/in/tristan-jander/" target="_blank" class="block text-blue-500 text-center mt-2"><i class="fab fa-linkedin fa-lg"></i></a>
           </div>
           <div class="card">
-            <div class="card-inner">
-              <div class="card-front p-4">
-                <img src="static/assets/images/AKochell.JPG" alt="Alex R. Kochell" class="mx-auto h-40 w-40 object-cover">
-                <p class="mt-2 font-semibold">Alex R. Kochell</p>
-                <p class="text-sm">Director, Operations</p>
-              </div>
-              <div class="card-back p-4">
-                <p class="font-semibold">Alex R. Kochell</p>
-                <p class="text-sm mb-2">Finance '27</p>
-                <a href="https://www.linkedin.com/in/alex-kochell-8925492b9/" target="_blank" class="text-black"><i class="fab fa-linkedin fa-lg"></i></a>
-              </div>
-            </div>
+            <img src="static/assets/images/AKochell.JPG" alt="Alex R. Kochell" class="mx-auto h-40 w-40 object-cover">
+            <p class="mt-2 font-semibold text-center">Alex R. Kochell</p>
+            <p class="text-sm text-center">Director of Operations</p>
+            <p class="text-sm text-center mb-2">Finance '27</p>
+            <a href="https://www.linkedin.com/in/alex-kochell-8925492b9/" target="_blank" class="block text-blue-500 text-center mt-2"><i class="fab fa-linkedin fa-lg"></i></a>
           </div>
         </div>
     </section>

--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -112,49 +112,17 @@ nav {
   transform: scale(2);
 }
 
-/* Team card flip effect */
+/* Team card layout */
 .card {
   width: 200px;
-  height: 250px;
   margin: 1rem auto;
-  perspective: 1000px;
-  cursor: pointer;
-}
-
-.card-inner {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  transition: transform 0.6s;
-  transform-style: preserve-3d;
-}
-
-.card:hover .card-inner {
-  transform: rotateY(180deg);
-}
-
-.card-front,
-.card-back {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  backface-visibility: hidden;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  border-radius: 0;
   text-align: center;
   background: rgba(255, 255, 255, 0.1);
   border: 1px solid rgba(255, 255, 255, 0.2);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
-}
-
-.card-back {
-  color: var(--openai-white);
-  transform: rotateY(180deg);
+  padding: 1rem;
 }
 
 /* Instagram marquee */


### PR DESCRIPTION
## Summary
- Remove hover flip effect from leadership cards and display member details beneath photos.
- Add blue LinkedIn icons and ensure names, roles, and majors are centered on separate lines.

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6890e48ce2c8832da75ad5710179b6b0