### PR TITLE
Make navigation bar sticky

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -10,7 +10,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
-  <nav class="glass shadow rounded-none sticky top-0 w-full z-50">
+  <nav class="glass shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
       <div class="flex items-center py-4">
         <a href="index.html" class="flex items-center">

--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -10,7 +10,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
-  <nav class="glass shadow rounded-none sticky top-0 w-full z-50">
+  <nav class="glass shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
       <div class="flex items-center py-4">
         <a href="index.html" class="flex items-center">

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,7 +18,7 @@
   </script>
 </head>
 <body class="flex flex-col min-h-screen">
-  <nav class="glass shadow rounded-none sticky top-0 w-full z-50">
+  <nav class="glass shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
       <div class="flex items-center py-4">
         <a href="#home" class="flex items-center">

--- a/docs/instagram.html
+++ b/docs/instagram.html
@@ -10,7 +10,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
-  <nav class="glass shadow rounded-none sticky top-0 w-full z-50">
+  <nav class="glass shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
       <div class="flex items-center py-4">
         <a href="index.html" class="flex items-center">

--- a/docs/join.html
+++ b/docs/join.html
@@ -10,7 +10,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
-  <nav class="glass shadow rounded-none sticky top-0 w-full z-50">
+  <nav class="glass shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
       <div class="flex items-center py-4">
         <a href="index.html" class="flex items-center">

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -10,7 +10,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
-  <nav class="glass shadow rounded-none sticky top-0 w-full z-50">
+  <nav class="glass shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
       <div class="flex items-center py-4">
         <a href="index.html" class="flex items-center">

--- a/docs/schedule.html
+++ b/docs/schedule.html
@@ -10,7 +10,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
-  <nav class="glass shadow rounded-none sticky top-0 w-full z-50">
+  <nav class="glass shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
       <div class="flex items-center py-4">
         <a href="index.html" class="flex items-center">

--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -10,7 +10,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
-  <nav class="glass shadow rounded-none sticky top-0 w-full z-50">
+  <nav class="glass shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
       <div class="flex items-center py-4">
         <a href="index.html" class="flex items-center">

--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -39,7 +39,7 @@ main h6 {
 }
 
 /* Sticky navigation bar */
-nav {
+.sticky-nav {
   position: -webkit-sticky; /* Safari compatibility */
   position: sticky;
   top: 0;


### PR DESCRIPTION
## Summary
- ensure navigation header stays visible by introducing a dedicated sticky-nav class
- apply sticky-nav class to navigation elements across all pages

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_b_68910aa30b90832dade8063d254eb51f