### PR TITLE
Slow header typing and fade tagline

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -46,7 +46,7 @@
       <section class="text-center py-3">
         <div class="max-w-4xl mx-auto">
           <h1 class="text-2xl font-bold text-gray-700">Welcome to the Financial Modeling Club</h1>
-          <p id="intro-message" class="mt-2 italic">Combining advice from professionals in finance with student-led workshops to develop essential financial modeling skills</p>
+          <p id="intro-message" class="mt-2 italic fade-in-block">Combining advice from professionals in finance with student-led workshops to develop essential financial modeling skills</p>
         </div>
       </section>
 

--- a/docs/static/js/scripts.js
+++ b/docs/static/js/scripts.js
@@ -41,7 +41,7 @@ function initFMC() {
         if (entry.isIntersecting && !entry.target.dataset.animated) {
           const el = entry.target;
           const text = el.dataset.typing;
-          typeText(el, text, 68); // slowed typing by 50%
+          typeText(el, text, 102); // slowed typing by 50%
           el.dataset.animated = 'true';
           observer.unobserve(el);
         }


### PR DESCRIPTION
## Summary
- Ensure home page tagline fades in at the same pace as other descriptions
- Slow down header typing animation by 50%

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68910b147d50832d83e28f6751b9e10e