### PR TITLE
Keep navigation bar fixed on scroll

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -15,6 +15,7 @@ body {
   background-image: none !important;
   color: var(--openai-white) !important;
   overflow-x: hidden;
+  padding-top: 8rem;
 }
 
 /* Navigation uses default system fonts to keep non-nav text in Inter */
@@ -40,9 +41,9 @@ main h6 {
 
 /* Sticky navigation bar */
 .sticky-nav {
-  position: -webkit-sticky; /* Safari compatibility */
-  position: sticky;
+  position: fixed;
   top: 0;
+  left: 0;
   width: 100%;
   z-index: 50;
 }

--- a/docs/static/js/scripts.js
+++ b/docs/static/js/scripts.js
@@ -95,7 +95,9 @@ function initFMC() {
         if (target) {
           e.preventDefault();
           const start = window.scrollY;
-          const end = target.getBoundingClientRect().top + start;
+          const nav = document.querySelector('.sticky-nav');
+          const navHeight = nav ? nav.offsetHeight : 0;
+          const end = target.getBoundingClientRect().top + start - navHeight;
           const duration = 1800; // slowed scroll by 50%
           const startTime = performance.now();
 


### PR DESCRIPTION
## Summary
- make the navigation bar fixed at the top of the viewport
- add body padding so content isn't hidden by the fixed bar
- offset smooth scroll targets by the nav bar height

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68910ee487f0832d85303e727f7fa896