### PR TITLE
Improve visibility of LinkedIn and Instagram icons

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -268,8 +268,8 @@ main h6 {
 
 /* Instagram follow icon styles */
 .insta-icon {
-  background: rgba(255, 255, 255, 0.15);
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.225);
+  border: 1px solid rgba(255, 255, 255, 0.45);
   border-radius: 50%;
   padding: 0.5rem;
   backdrop-filter: blur(4px);
@@ -289,8 +289,8 @@ main h6 {
 }
 
 .linkedin-icon {
-  background: rgba(255, 255, 255, 0.15);
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.225);
+  border: 1px solid rgba(255, 255, 255, 0.45);
   border-radius: 50%;
   padding: 0.5rem;
   backdrop-filter: blur(4px);


### PR DESCRIPTION
## Summary
- increase background and border opacity for LinkedIn and Instagram icons by 50%

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68910f833670832db6866d311674ba28