### PR TITLE
Show four Instagram images without fade and slow carousel

### DIFF
--- a/docs/instagram.html
+++ b/docs/instagram.html
@@ -39,37 +39,37 @@
         <h2 class="text-xl font-bold mb-4 text-center">Latest on Instagram</h2>
         <div class="insta-marquee">
           <div class="insta-row insta-row-fast">
-            <div class="insta-item glass flex-none w-1/12">
+            <div class="insta-item glass flex-none w-1/4">
               <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
                 <img src="https://unsplash.it/800/400" alt="Workshop attendees collaborating" class="h-48 w-full object-cover">
               </a>
               <small class="block text-center mt-1">Mar 12, 2025 • Modeling Workshop</small>
             </div>
-            <div class="insta-item glass flex-none w-1/12">
+            <div class="insta-item glass flex-none w-1/4">
               <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
                 <img src="https://unsplash.it/800/400" alt="Guest speaker presenting" class="h-48 w-full object-cover">
               </a>
               <small class="block text-center mt-1">Feb 27, 2025 • Guest Speaker</small>
             </div>
-            <div class="insta-item glass flex-none w-1/12">
+            <div class="insta-item glass flex-none w-1/4">
               <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
                 <img src="https://unsplash.it/800/400" alt="Networking social event" class="h-48 w-full object-cover">
               </a>
               <small class="block text-center mt-1">Jan 18, 2025 • Networking Social</small>
             </div>
-            <div class="insta-item glass flex-none w-1/12">
+            <div class="insta-item glass flex-none w-1/4">
               <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
                 <img src="https://unsplash.it/800/400" alt="Team building workshop" class="h-48 w-full object-cover">
               </a>
               <small class="block text-center mt-1">Dec 02, 2024 • Team Workshop</small>
             </div>
-            <div class="insta-item glass flex-none w-1/12">
+            <div class="insta-item glass flex-none w-1/4">
               <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
                 <img src="https://unsplash.it/800/400" alt="Case competition" class="h-48 w-full object-cover">
               </a>
               <small class="block text-center mt-1">Nov 20, 2024 • Case Competition</small>
             </div>
-            <div class="insta-item glass flex-none w-1/12">
+            <div class="insta-item glass flex-none w-1/4">
               <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
                 <img src="https://unsplash.it/800/400" alt="Holiday social" class="h-48 w-full object-cover">
               </a>
@@ -77,37 +77,37 @@
             </div>
           </div>
           <div class="insta-row insta-row-slow">
-            <div class="insta-item glass flex-none w-1/12">
+            <div class="insta-item glass flex-none w-1/4">
               <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
                 <img src="https://unsplash.it/800/400" alt="Workshop attendees collaborating" class="h-48 w-full object-cover">
               </a>
               <small class="block text-center mt-1">Mar 12, 2025 • Modeling Workshop</small>
             </div>
-            <div class="insta-item glass flex-none w-1/12">
+            <div class="insta-item glass flex-none w-1/4">
               <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
                 <img src="https://unsplash.it/800/400" alt="Guest speaker presenting" class="h-48 w-full object-cover">
               </a>
               <small class="block text-center mt-1">Feb 27, 2025 • Guest Speaker</small>
             </div>
-            <div class="insta-item glass flex-none w-1/12">
+            <div class="insta-item glass flex-none w-1/4">
               <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
                 <img src="https://unsplash.it/800/400" alt="Networking social event" class="h-48 w-full object-cover">
               </a>
               <small class="block text-center mt-1">Jan 18, 2025 • Networking Social</small>
             </div>
-            <div class="insta-item glass flex-none w-1/12">
+            <div class="insta-item glass flex-none w-1/4">
               <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
                 <img src="https://unsplash.it/800/400" alt="Team building workshop" class="h-48 w-full object-cover">
               </a>
               <small class="block text-center mt-1">Dec 02, 2024 • Team Workshop</small>
             </div>
-            <div class="insta-item glass flex-none w-1/12">
+            <div class="insta-item glass flex-none w-1/4">
               <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
                 <img src="https://unsplash.it/800/400" alt="Case competition" class="h-48 w-full object-cover">
               </a>
               <small class="block text-center mt-1">Nov 20, 2024 • Case Competition</small>
             </div>
-            <div class="insta-item glass flex-none w-1/12">
+            <div class="insta-item glass flex-none w-1/4">
               <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
                 <img src="https://unsplash.it/800/400" alt="Holiday social" class="h-48 w-full object-cover">
               </a>

--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -138,38 +138,17 @@ main h6 {
 }
 
 .insta-item {
-  flex: 0 0 8.3333%;
+  flex: 0 0 25%;
 }
 
 .insta-row-fast {
-  animation: insta-scroll 40s linear infinite;
+  animation: insta-scroll 50s linear infinite;
 }
 
 .insta-row-slow {
-  animation: insta-scroll 60s linear infinite;
-  animation-delay: -30s;
+  animation: insta-scroll 75s linear infinite;
+  animation-delay: -37.5s;
   margin-top: 1rem;
-}
-
-.insta-marquee::before,
-.insta-marquee::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  width: 4rem;
-  height: 100%;
-  pointer-events: none;
-  z-index: 10;
-}
-
-.insta-marquee::before {
-  left: 0;
-  background: linear-gradient(to right, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0));
-}
-
-.insta-marquee::after {
-  right: 0;
-  background: linear-gradient(to left, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0));
 }
 
   @keyframes insta-scroll {


### PR DESCRIPTION
## Summary
- Remove edge-fade overlay from Instagram reel to show images without gradient fade.
- Display four Instagram photos at once and reduce carousel speed.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6891105e99d0832da08ea287c7e1e5e2