### PR TITLE
Update speaker of the week card

### DIFF
--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -36,16 +36,8 @@
   <main class="flex-grow py-8 glass m-4">
     <section class="max-w-3xl mx-auto px-4 text-center">
       <h1 class="text-3xl font-bold mb-4">Speaker of the Week</h1>
-      <div class="card">
-        <div class="card-inner">
-          <div class="card-front flex flex-col">
-            <h2 class="text-xl font-semibold">Alex Johnson</h2>
-            <p class="mt-2 text-sm">Senior Analyst, Capital Co.</p>
-          </div>
-          <div class="card-back p-4 flex flex-col">
-            <p>Alex will share tips on building dynamic models in Excel during this week's meeting.</p>
-          </div>
-        </div>
+      <div class="card speaker-card">
+        <img src="static/assets/images/61e078a2-a487-4882-99f0-f35db1ee22c3.jpg" alt="Speaker of the Week">
       </div>
     </section>
   </main>

--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -126,6 +126,19 @@ main h6 {
   padding: 1rem;
 }
 
+/* Speaker of the Week card */
+.speaker-card {
+  display: inline-block;
+  width: auto;
+  padding: 0;
+}
+
+.speaker-card img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
 /* Instagram marquee */
 .insta-marquee {
   overflow: hidden;


### PR DESCRIPTION
## Summary
- Show the speaker of the week photo on the speaker page
- Add CSS that allows the speaker card to size to the image

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68911357de58832d8b1a0d79faa940a3