### PR TITLE
Remove glass animations from icons and make team cards transparent

### DIFF
--- a/docs/instagram.html
+++ b/docs/instagram.html
@@ -117,7 +117,7 @@
         </div>
         <p class="mt-3 text-center">
           <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram" class="inline-block">
-            <span class="insta-icon logo-shimmer hover-jiggle">
+            <span class="insta-icon">
               <i class="fa-brands fa-instagram text-5xl insta-color"></i>
             </span>
           </a>

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -46,7 +46,7 @@
             <p class="text-sm text-center">President &amp; Founder</p>
             <p class="text-sm text-center mb-2">Finance '27</p>
             <a href="https://www.linkedin.com/in/davis-sawyer-wm2027/" target="_blank" class="block text-center mt-2">
-              <span class="linkedin-icon logo-shimmer hover-jiggle">
+              <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>
               </span>
             </a>
@@ -57,7 +57,7 @@
             <p class="text-sm text-center">VP, Financial Modeling</p>
             <p class="text-sm text-center mb-2">Computer Science '27</p>
             <a href="https://www.linkedin.com/in/jack-aitken-b516a5282/" target="_blank" class="block text-center mt-2">
-              <span class="linkedin-icon logo-shimmer hover-jiggle">
+              <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>
               </span>
             </a>
@@ -69,7 +69,7 @@
             <p class="text-sm text-center">Applied Math '25</p>
             <p class="text-sm text-center mb-2">MS Computer Science '27</p>
             <a href="https://www.linkedin.com/in/daniel-butler-a1ba3a296/" target="_blank" class="block text-center mt-2">
-              <span class="linkedin-icon logo-shimmer hover-jiggle">
+              <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>
               </span>
             </a>
@@ -80,7 +80,7 @@
             <p class="text-sm text-center">VP, Mentorship</p>
             <p class="text-sm text-center mb-2">History &amp; Religion '27</p>
             <a href="https://www.linkedin.com/in/tom-chesnut-2593a329b/" target="_blank" class="block text-center mt-2">
-              <span class="linkedin-icon logo-shimmer hover-jiggle">
+              <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>
               </span>
             </a>
@@ -91,7 +91,7 @@
             <p class="text-sm text-center">VP, Marketing</p>
             <p class="text-sm text-center mb-2">Economics '26</p>
             <a href="https://www.linkedin.com/in/luke-archey-a23668263/" target="_blank" class="block text-center mt-2">
-              <span class="linkedin-icon logo-shimmer hover-jiggle">
+              <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>
               </span>
             </a>
@@ -102,7 +102,7 @@
             <p class="text-sm text-center">VP, Finance</p>
             <p class="text-sm text-center mb-2">Economics '26</p>
             <a href="https://www.linkedin.com/in/benmichaud1/" target="_blank" class="block text-center mt-2">
-              <span class="linkedin-icon logo-shimmer hover-jiggle">
+              <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>
               </span>
             </a>
@@ -122,7 +122,7 @@
             <p class="text-sm text-center">Director, Marketing</p>
             <p class="text-sm text-center mb-2">Finance '27</p>
             <a href="https://www.linkedin.com/in/audreysims" target="_blank" class="block text-center mt-2">
-              <span class="linkedin-icon logo-shimmer hover-jiggle">
+              <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>
               </span>
             </a>
@@ -133,7 +133,7 @@
             <p class="text-sm text-center">Director, Finance</p>
             <p class="text-sm text-center mb-2">Accounting '27</p>
             <a href="https://www.linkedin.com/in/tristan-jander/" target="_blank" class="block text-center mt-2">
-              <span class="linkedin-icon logo-shimmer hover-jiggle">
+              <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>
               </span>
             </a>
@@ -144,7 +144,7 @@
             <p class="text-sm text-center">Director of Operations</p>
             <p class="text-sm text-center mb-2">Finance '27</p>
             <a href="https://www.linkedin.com/in/alex-kochell-8925492b9/" target="_blank" class="block text-center mt-2">
-              <span class="linkedin-icon logo-shimmer hover-jiggle">
+              <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>
               </span>
             </a>

--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -118,11 +118,11 @@ main h6 {
   width: 200px;
   margin: 1rem auto;
   text-align: center;
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+  background: transparent;
+  border: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  box-shadow: none;
   padding: 1rem;
 }
 
@@ -248,12 +248,8 @@ main h6 {
 
 /* Instagram follow icon styles */
 .insta-icon {
-  background: rgba(255, 255, 255, 0.225);
-  border: 1px solid rgba(255, 255, 255, 0.45);
   border-radius: 50%;
   padding: 0.5rem;
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
   display: inline-block;
 }
 
@@ -269,12 +265,8 @@ main h6 {
 }
 
 .linkedin-icon {
-  background: rgba(255, 255, 255, 0.225);
-  border: 1px solid rgba(255, 255, 255, 0.45);
   border-radius: 50%;
   padding: 0.5rem;
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
   display: inline-block;
 }
 


### PR DESCRIPTION
## Summary
- Make team cards fully transparent instead of glass-styled
- Remove shimmer and jiggle classes from LinkedIn and Instagram icons
- Simplify icon styling for LinkedIn and Instagram to eliminate glassmorphic effects

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689114913408832d86d502dc45deac03