### PR TITLE
Make nav opaque and fix scroll offset

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -48,6 +48,11 @@ main h6 {
   z-index: 50;
 }
 
+/* Increase nav opacity but keep background blending */
+.sticky-nav.glass {
+  background-color: rgba(0, 0, 0, 0.5) !important;
+}
+
 /* Transparent glassmorphic utility */
 .glass {
   background: transparent !important;

--- a/docs/static/js/scripts.js
+++ b/docs/static/js/scripts.js
@@ -113,7 +113,8 @@ function initFMC() {
             if (time < 1) {
               requestAnimationFrame(step);
             } else {
-              window.location.hash = targetId;
+              window.scrollTo(0, end);
+              history.replaceState(null, '', '#' + targetId);
             }
           }
 


### PR DESCRIPTION
## Summary
- increase sticky nav opacity with background-matched color
- smooth-scroll to anchors without hash jump and stop at section top

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_b_689117bfe034832d80d35a7996e139f5