### PR TITLE
Make navbar fully opaque

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -48,9 +48,9 @@ main h6 {
   z-index: 50;
 }
 
-/* Increase nav opacity but keep background blending */
+/* Opaque navigation bar matching background */
 .sticky-nav.glass {
-  background-color: rgba(0, 0, 0, 0.5) !important;
+  background-color: var(--openai-black) !important;
 }
 
 /* Transparent glassmorphic utility */


### PR DESCRIPTION
## Summary
- make sticky navigation bar fully opaque and match the page background

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689119d40b50832d9798011b974bca6c