### PR TITLE
Ensure eight Instagram photos are always visible

### DIFF
--- a/docs/instagram.html
+++ b/docs/instagram.html
@@ -39,79 +39,103 @@
         <h2 class="text-xl font-bold mb-4 text-center">Latest on Instagram</h2>
         <div class="insta-marquee">
           <div class="insta-row insta-row-fast">
-            <div class="insta-item glass flex-none w-1/4">
+            <div class="insta-item glass">
               <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
                 <img src="https://unsplash.it/800/400" alt="Workshop attendees collaborating" class="h-48 w-full object-cover">
               </a>
               <small class="block text-center mt-1">Mar 12, 2025 • Modeling Workshop</small>
             </div>
-            <div class="insta-item glass flex-none w-1/4">
+            <div class="insta-item glass">
               <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
                 <img src="https://unsplash.it/800/400" alt="Guest speaker presenting" class="h-48 w-full object-cover">
               </a>
               <small class="block text-center mt-1">Feb 27, 2025 • Guest Speaker</small>
             </div>
-            <div class="insta-item glass flex-none w-1/4">
+            <div class="insta-item glass">
               <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
                 <img src="https://unsplash.it/800/400" alt="Networking social event" class="h-48 w-full object-cover">
               </a>
               <small class="block text-center mt-1">Jan 18, 2025 • Networking Social</small>
             </div>
-            <div class="insta-item glass flex-none w-1/4">
+            <div class="insta-item glass">
               <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
                 <img src="https://unsplash.it/800/400" alt="Team building workshop" class="h-48 w-full object-cover">
               </a>
               <small class="block text-center mt-1">Dec 02, 2024 • Team Workshop</small>
             </div>
-            <div class="insta-item glass flex-none w-1/4">
+            <div class="insta-item glass">
               <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
                 <img src="https://unsplash.it/800/400" alt="Case competition" class="h-48 w-full object-cover">
               </a>
               <small class="block text-center mt-1">Nov 20, 2024 • Case Competition</small>
             </div>
-            <div class="insta-item glass flex-none w-1/4">
+            <div class="insta-item glass">
               <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
                 <img src="https://unsplash.it/800/400" alt="Holiday social" class="h-48 w-full object-cover">
               </a>
               <small class="block text-center mt-1">Oct 15, 2024 • Holiday Social</small>
+            </div>
+            <div class="insta-item glass">
+              <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
+                <img src="https://unsplash.it/800/400" alt="Kickoff meeting" class="h-48 w-full object-cover">
+              </a>
+              <small class="block text-center mt-1">Sep 10, 2024 • Kickoff Meeting</small>
+            </div>
+            <div class="insta-item glass">
+              <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
+                <img src="https://unsplash.it/800/400" alt="Summer project collaboration" class="h-48 w-full object-cover">
+              </a>
+              <small class="block text-center mt-1">Aug 05, 2024 • Summer Project</small>
             </div>
           </div>
           <div class="insta-row insta-row-slow">
-            <div class="insta-item glass flex-none w-1/4">
+            <div class="insta-item glass">
               <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
                 <img src="https://unsplash.it/800/400" alt="Workshop attendees collaborating" class="h-48 w-full object-cover">
               </a>
               <small class="block text-center mt-1">Mar 12, 2025 • Modeling Workshop</small>
             </div>
-            <div class="insta-item glass flex-none w-1/4">
+            <div class="insta-item glass">
               <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
                 <img src="https://unsplash.it/800/400" alt="Guest speaker presenting" class="h-48 w-full object-cover">
               </a>
               <small class="block text-center mt-1">Feb 27, 2025 • Guest Speaker</small>
             </div>
-            <div class="insta-item glass flex-none w-1/4">
+            <div class="insta-item glass">
               <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
                 <img src="https://unsplash.it/800/400" alt="Networking social event" class="h-48 w-full object-cover">
               </a>
               <small class="block text-center mt-1">Jan 18, 2025 • Networking Social</small>
             </div>
-            <div class="insta-item glass flex-none w-1/4">
+            <div class="insta-item glass">
               <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
                 <img src="https://unsplash.it/800/400" alt="Team building workshop" class="h-48 w-full object-cover">
               </a>
               <small class="block text-center mt-1">Dec 02, 2024 • Team Workshop</small>
             </div>
-            <div class="insta-item glass flex-none w-1/4">
+            <div class="insta-item glass">
               <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
                 <img src="https://unsplash.it/800/400" alt="Case competition" class="h-48 w-full object-cover">
               </a>
               <small class="block text-center mt-1">Nov 20, 2024 • Case Competition</small>
             </div>
-            <div class="insta-item glass flex-none w-1/4">
+            <div class="insta-item glass">
               <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
                 <img src="https://unsplash.it/800/400" alt="Holiday social" class="h-48 w-full object-cover">
               </a>
               <small class="block text-center mt-1">Oct 15, 2024 • Holiday Social</small>
+            </div>
+            <div class="insta-item glass">
+              <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
+                <img src="https://unsplash.it/800/400" alt="Kickoff meeting" class="h-48 w-full object-cover">
+              </a>
+              <small class="block text-center mt-1">Sep 10, 2024 • Kickoff Meeting</small>
+            </div>
+            <div class="insta-item glass">
+              <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" rel="noopener noreferrer">
+                <img src="https://unsplash.it/800/400" alt="Summer project collaboration" class="h-48 w-full object-cover">
+              </a>
+              <small class="block text-center mt-1">Aug 05, 2024 • Summer Project</small>
             </div>
           </div>
         </div>

--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -143,7 +143,8 @@ main h6 {
 }
 
 .insta-item {
-  flex: 0 0 25%;
+  flex: 0 0 12.5%;
+  max-width: 12.5%;
 }
 
 .insta-row-fast {


### PR DESCRIPTION
## Summary
- Adjusted Instagram carousel item width to 12.5% so eight images fit on screen.
- Added two additional Instagram items to each scrolling row to keep eight photos visible.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689124ffb6c0832d8d2cea61140d40cc