### PR TITLE
Prevent line wrap for MS Computer Science text

### DIFF
--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -67,7 +67,7 @@
             <p class="mt-2 font-semibold text-center">Daniel R. Butler</p>
             <p class="text-sm text-center">VP, Operations</p>
             <p class="text-sm text-center">Applied Math '25</p>
-            <p class="text-sm text-center mb-2">MS Computer Science '27</p>
+            <p class="text-sm text-center mb-2 whitespace-nowrap">MS Computer Science '27</p>
             <a href="https://www.linkedin.com/in/daniel-butler-a1ba3a296/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>


### PR DESCRIPTION
## Summary
- avoid wrapping for the "MS Computer Science '27" tagline on the leadership page

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_b_68912a2ae7c0832d842f9f6f07aafe30