### PR TITLE
Update navigation layout and styling

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -12,17 +12,16 @@
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="flex items-center py-4">
+      <div class="flex items-center py-4 relative">
         <a href="index.html" class="flex items-center">
           <div class="logo-shimmer hover-jiggle">
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
           <div class="ml-2 hover-jiggle">
-            <span class="block text-3xl">Financial Modeling Club</span>
-            <span class="block text-sm">at William & Mary</span>
+            <span class="block text-[1.40625rem] whitespace-nowrap">Financial Modeling Club @ William & Mary</span>
           </div>
         </a>
-        <ul class="flex space-x-4 justify-center mx-auto">
+        <ul class="flex space-x-4 justify-center absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
           <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
           <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>

--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -12,17 +12,16 @@
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="flex items-center py-4">
+      <div class="flex items-center py-4 relative">
         <a href="index.html" class="flex items-center">
           <div class="logo-shimmer hover-jiggle">
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
           <div class="ml-2 hover-jiggle">
-            <span class="block text-3xl">Financial Modeling Club</span>
-            <span class="block text-sm">at William & Mary</span>
+            <span class="block text-[1.40625rem] whitespace-nowrap">Financial Modeling Club @ William & Mary</span>
           </div>
         </a>
-        <ul class="flex space-x-4 justify-center mx-auto">
+        <ul class="flex space-x-4 justify-center absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
           <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
           <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,17 +20,16 @@
 <body class="flex flex-col min-h-screen">
   <nav class="glass shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="flex items-center py-4">
+      <div class="flex items-center py-4 relative">
         <a href="#home" class="flex items-center">
           <div class="logo-shimmer hover-jiggle">
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
           <div class="ml-2 hover-jiggle">
-            <span class="block text-3xl">Financial Modeling Club</span>
-            <span class="block text-sm">at William & Mary</span>
+            <span class="block text-[1.40625rem] whitespace-nowrap">Financial Modeling Club @ William & Mary</span>
           </div>
         </a>
-        <ul class="flex space-x-4 justify-center mx-auto">
+        <ul class="flex space-x-4 justify-center absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
           <li><a href="#home" class="hover-jiggle no-underline"><span>Home</span></a></li>
           <li><a href="#howwework" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
           <li><a href="#leadership" class="hover-jiggle no-underline"><span>Our Team</span></a></li>

--- a/docs/instagram.html
+++ b/docs/instagram.html
@@ -12,17 +12,16 @@
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="flex items-center py-4">
+      <div class="flex items-center py-4 relative">
         <a href="index.html" class="flex items-center">
           <div class="logo-shimmer hover-jiggle">
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
           <div class="ml-2 hover-jiggle">
-            <span class="block text-3xl">Financial Modeling Club</span>
-            <span class="block text-sm">at William & Mary</span>
+            <span class="block text-[1.40625rem] whitespace-nowrap">Financial Modeling Club @ William & Mary</span>
           </div>
         </a>
-        <ul class="flex space-x-4 justify-center mx-auto">
+        <ul class="flex space-x-4 justify-center absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
           <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
           <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>

--- a/docs/join.html
+++ b/docs/join.html
@@ -12,17 +12,16 @@
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="flex items-center py-4">
+      <div class="flex items-center py-4 relative">
         <a href="index.html" class="flex items-center">
           <div class="logo-shimmer hover-jiggle">
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
           <div class="ml-2 hover-jiggle">
-            <span class="block text-3xl">Financial Modeling Club</span>
-            <span class="block text-sm">at William & Mary</span>
+            <span class="block text-[1.40625rem] whitespace-nowrap">Financial Modeling Club @ William & Mary</span>
           </div>
         </a>
-        <ul class="flex space-x-4 justify-center mx-auto">
+        <ul class="flex space-x-4 justify-center absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
           <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
           <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -12,17 +12,16 @@
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="flex items-center py-4">
+      <div class="flex items-center py-4 relative">
         <a href="index.html" class="flex items-center">
           <div class="logo-shimmer hover-jiggle">
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
           <div class="ml-2 hover-jiggle">
-            <span class="block text-3xl">Financial Modeling Club</span>
-            <span class="block text-sm">at William & Mary</span>
+            <span class="block text-[1.40625rem] whitespace-nowrap">Financial Modeling Club @ William & Mary</span>
           </div>
         </a>
-        <ul class="flex space-x-4 justify-center mx-auto">
+        <ul class="flex space-x-4 justify-center absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
           <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
           <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>

--- a/docs/schedule.html
+++ b/docs/schedule.html
@@ -12,17 +12,16 @@
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="flex items-center py-4">
+      <div class="flex items-center py-4 relative">
         <a href="index.html" class="flex items-center">
           <div class="logo-shimmer hover-jiggle">
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
           <div class="ml-2 hover-jiggle">
-            <span class="block text-3xl">Financial Modeling Club</span>
-            <span class="block text-sm">at William & Mary</span>
+            <span class="block text-[1.40625rem] whitespace-nowrap">Financial Modeling Club @ William & Mary</span>
           </div>
         </a>
-        <ul class="flex space-x-4 justify-center mx-auto">
+        <ul class="flex space-x-4 justify-center absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
           <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
           <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>

--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -12,17 +12,16 @@
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="flex items-center py-4">
+      <div class="flex items-center py-4 relative">
         <a href="index.html" class="flex items-center">
           <div class="logo-shimmer hover-jiggle">
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
           <div class="ml-2 hover-jiggle">
-            <span class="block text-3xl">Financial Modeling Club</span>
-            <span class="block text-sm">at William & Mary</span>
+            <span class="block text-[1.40625rem] whitespace-nowrap">Financial Modeling Club @ William & Mary</span>
           </div>
         </a>
-        <ul class="flex space-x-4 justify-center mx-auto">
+        <ul class="flex space-x-4 justify-center absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
           <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
           <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>

--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -21,6 +21,13 @@ nav, nav * {
   font-family: Helvetica, Arial, sans-serif;
 }
 
+/* Bubble borders for navigation tabs */
+nav ul li a {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 9999px;
+  padding: 0.25rem 0.75rem;
+}
+
 body * {
   color: var(--openai-white) !important;
 }


### PR DESCRIPTION
## Summary
- Centered navigation tabs and kept "Sign Up" on the right
- Replaced two-line title with single-line "Financial Modeling Club @ William & Mary" at smaller size
- Added translucent bubble borders around navigation tabs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68912c3612d0832d8a04ec16f2b28848