### PR TITLE
Center nav tabs and refine navbar title

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -18,17 +18,19 @@
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
           <div class="ml-2 hover-jiggle">
-            <span class="block text-3xl">Financial Modeling Club</span>
-            <span class="block text-sm">at William & Mary</span>
+            <span class="block nav-title">Financial Modeling Club</span>
+            <span class="block text-sm">@ William & Mary</span>
           </div>
         </a>
-        <ul class="flex space-x-4 justify-center mx-auto">
-          <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
-          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
-          <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
-          <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
-        </ul>
-        <a href="join.html" class="ml-auto hover-jiggle no-underline"><span>Sign Up</span></a>
+        <div class="flex-1">
+          <ul class="flex space-x-4 justify-center">
+            <li><a href="index.html" class="nav-tab hover-jiggle no-underline"><span>Home</span></a></li>
+            <li><a href="howwework.html" class="nav-tab hover-jiggle no-underline"><span>Meetings</span></a></li>
+            <li><a href="leadership.html" class="nav-tab hover-jiggle no-underline"><span>Our Team</span></a></li>
+            <li><a href="schedule.html" class="nav-tab hover-jiggle no-underline"><span>Schedule</span></a></li>
+          </ul>
+        </div>
+        <a href="join.html" class="ml-4 hover-jiggle no-underline"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -18,17 +18,19 @@
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
           <div class="ml-2 hover-jiggle">
-            <span class="block text-3xl">Financial Modeling Club</span>
-            <span class="block text-sm">at William & Mary</span>
+            <span class="block nav-title">Financial Modeling Club</span>
+            <span class="block text-sm">@ William & Mary</span>
           </div>
         </a>
-        <ul class="flex space-x-4 justify-center mx-auto">
-          <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
-          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
-          <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
-          <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
-        </ul>
-        <a href="join.html" class="ml-auto hover-jiggle no-underline"><span>Sign Up</span></a>
+        <div class="flex-1">
+          <ul class="flex space-x-4 justify-center">
+            <li><a href="index.html" class="nav-tab hover-jiggle no-underline"><span>Home</span></a></li>
+            <li><a href="howwework.html" class="nav-tab hover-jiggle no-underline"><span>Meetings</span></a></li>
+            <li><a href="leadership.html" class="nav-tab hover-jiggle no-underline"><span>Our Team</span></a></li>
+            <li><a href="schedule.html" class="nav-tab hover-jiggle no-underline"><span>Schedule</span></a></li>
+          </ul>
+        </div>
+        <a href="join.html" class="ml-4 hover-jiggle no-underline"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,17 +26,19 @@
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
           <div class="ml-2 hover-jiggle">
-            <span class="block text-3xl">Financial Modeling Club</span>
-            <span class="block text-sm">at William & Mary</span>
+            <span class="block nav-title">Financial Modeling Club</span>
+            <span class="block text-sm">@ William & Mary</span>
           </div>
         </a>
-        <ul class="flex space-x-4 justify-center mx-auto">
-          <li><a href="#home" class="hover-jiggle no-underline"><span>Home</span></a></li>
-          <li><a href="#howwework" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
-          <li><a href="#leadership" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
-          <li><a href="#schedule" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
-        </ul>
-        <a href="#join" class="ml-auto hover-jiggle no-underline"><span>Sign Up</span></a>
+        <div class="flex-1">
+          <ul class="flex space-x-4 justify-center">
+            <li><a href="#home" class="nav-tab hover-jiggle no-underline"><span>Home</span></a></li>
+            <li><a href="#howwework" class="nav-tab hover-jiggle no-underline"><span>Meetings</span></a></li>
+            <li><a href="#leadership" class="nav-tab hover-jiggle no-underline"><span>Our Team</span></a></li>
+            <li><a href="#schedule" class="nav-tab hover-jiggle no-underline"><span>Schedule</span></a></li>
+          </ul>
+        </div>
+        <a href="#join" class="ml-4 hover-jiggle no-underline"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/instagram.html
+++ b/docs/instagram.html
@@ -18,17 +18,19 @@
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
           <div class="ml-2 hover-jiggle">
-            <span class="block text-3xl">Financial Modeling Club</span>
-            <span class="block text-sm">at William & Mary</span>
+            <span class="block nav-title">Financial Modeling Club</span>
+            <span class="block text-sm">@ William & Mary</span>
           </div>
         </a>
-        <ul class="flex space-x-4 justify-center mx-auto">
-          <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
-          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
-          <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
-          <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
-        </ul>
-        <a href="join.html" class="ml-auto hover-jiggle no-underline"><span>Sign Up</span></a>
+        <div class="flex-1">
+          <ul class="flex space-x-4 justify-center">
+            <li><a href="index.html" class="nav-tab hover-jiggle no-underline"><span>Home</span></a></li>
+            <li><a href="howwework.html" class="nav-tab hover-jiggle no-underline"><span>Meetings</span></a></li>
+            <li><a href="leadership.html" class="nav-tab hover-jiggle no-underline"><span>Our Team</span></a></li>
+            <li><a href="schedule.html" class="nav-tab hover-jiggle no-underline"><span>Schedule</span></a></li>
+          </ul>
+        </div>
+        <a href="join.html" class="ml-4 hover-jiggle no-underline"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/join.html
+++ b/docs/join.html
@@ -18,17 +18,19 @@
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
           <div class="ml-2 hover-jiggle">
-            <span class="block text-3xl">Financial Modeling Club</span>
-            <span class="block text-sm">at William & Mary</span>
+            <span class="block nav-title">Financial Modeling Club</span>
+            <span class="block text-sm">@ William & Mary</span>
           </div>
         </a>
-        <ul class="flex space-x-4 justify-center mx-auto">
-          <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
-          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
-          <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
-          <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
-        </ul>
-        <a href="join.html" class="ml-auto hover-jiggle no-underline"><span>Sign Up</span></a>
+        <div class="flex-1">
+          <ul class="flex space-x-4 justify-center">
+            <li><a href="index.html" class="nav-tab hover-jiggle no-underline"><span>Home</span></a></li>
+            <li><a href="howwework.html" class="nav-tab hover-jiggle no-underline"><span>Meetings</span></a></li>
+            <li><a href="leadership.html" class="nav-tab hover-jiggle no-underline"><span>Our Team</span></a></li>
+            <li><a href="schedule.html" class="nav-tab hover-jiggle no-underline"><span>Schedule</span></a></li>
+          </ul>
+        </div>
+        <a href="join.html" class="ml-4 hover-jiggle no-underline"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -18,17 +18,19 @@
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
           <div class="ml-2 hover-jiggle">
-            <span class="block text-3xl">Financial Modeling Club</span>
-            <span class="block text-sm">at William & Mary</span>
+            <span class="block nav-title">Financial Modeling Club</span>
+            <span class="block text-sm">@ William & Mary</span>
           </div>
         </a>
-        <ul class="flex space-x-4 justify-center mx-auto">
-          <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
-          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
-          <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
-          <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
-        </ul>
-        <a href="join.html" class="ml-auto hover-jiggle no-underline"><span>Sign Up</span></a>
+        <div class="flex-1">
+          <ul class="flex space-x-4 justify-center">
+            <li><a href="index.html" class="nav-tab hover-jiggle no-underline"><span>Home</span></a></li>
+            <li><a href="howwework.html" class="nav-tab hover-jiggle no-underline"><span>Meetings</span></a></li>
+            <li><a href="leadership.html" class="nav-tab hover-jiggle no-underline"><span>Our Team</span></a></li>
+            <li><a href="schedule.html" class="nav-tab hover-jiggle no-underline"><span>Schedule</span></a></li>
+          </ul>
+        </div>
+        <a href="join.html" class="ml-4 hover-jiggle no-underline"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/schedule.html
+++ b/docs/schedule.html
@@ -18,17 +18,19 @@
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
           <div class="ml-2 hover-jiggle">
-            <span class="block text-3xl">Financial Modeling Club</span>
-            <span class="block text-sm">at William & Mary</span>
+            <span class="block nav-title">Financial Modeling Club</span>
+            <span class="block text-sm">@ William & Mary</span>
           </div>
         </a>
-        <ul class="flex space-x-4 justify-center mx-auto">
-          <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
-          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
-          <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
-          <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
-        </ul>
-        <a href="join.html" class="ml-auto hover-jiggle no-underline"><span>Sign Up</span></a>
+        <div class="flex-1">
+          <ul class="flex space-x-4 justify-center">
+            <li><a href="index.html" class="nav-tab hover-jiggle no-underline"><span>Home</span></a></li>
+            <li><a href="howwework.html" class="nav-tab hover-jiggle no-underline"><span>Meetings</span></a></li>
+            <li><a href="leadership.html" class="nav-tab hover-jiggle no-underline"><span>Our Team</span></a></li>
+            <li><a href="schedule.html" class="nav-tab hover-jiggle no-underline"><span>Schedule</span></a></li>
+          </ul>
+        </div>
+        <a href="join.html" class="ml-4 hover-jiggle no-underline"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -18,17 +18,19 @@
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
           <div class="ml-2 hover-jiggle">
-            <span class="block text-3xl">Financial Modeling Club</span>
-            <span class="block text-sm">at William & Mary</span>
+            <span class="block nav-title">Financial Modeling Club</span>
+            <span class="block text-sm">@ William & Mary</span>
           </div>
         </a>
-        <ul class="flex space-x-4 justify-center mx-auto">
-          <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
-          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
-          <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
-          <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
-        </ul>
-        <a href="join.html" class="ml-auto hover-jiggle no-underline"><span>Sign Up</span></a>
+        <div class="flex-1">
+          <ul class="flex space-x-4 justify-center">
+            <li><a href="index.html" class="nav-tab hover-jiggle no-underline"><span>Home</span></a></li>
+            <li><a href="howwework.html" class="nav-tab hover-jiggle no-underline"><span>Meetings</span></a></li>
+            <li><a href="leadership.html" class="nav-tab hover-jiggle no-underline"><span>Our Team</span></a></li>
+            <li><a href="schedule.html" class="nav-tab hover-jiggle no-underline"><span>Schedule</span></a></li>
+          </ul>
+        </div>
+        <a href="join.html" class="ml-4 hover-jiggle no-underline"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -21,6 +21,20 @@ nav, nav * {
   font-family: Helvetica, Arial, sans-serif;
 }
 
+/* Nav title with reduced size */
+.nav-title {
+  font-size: 1.40625rem;
+}
+
+/* Bubble border style for nav tabs */
+.nav-tab {
+  display: inline-block;
+  border: 1px solid rgba(128, 0, 128, 0.7);
+  border-radius: 9999px;
+  padding: 0.25rem 0.75rem;
+  background-color: transparent;
+}
+
 body * {
   color: var(--openai-white) !important;
 }


### PR DESCRIPTION
## Summary
- Replace "at" with "@" in navbar title and shrink "Financial Modeling Club" by 25%.
- Center navigation tabs, keep Sign Up at far right, and add a subtle purple bubble border around tabs.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68912e9ec4d0832d9c2b35bbd763ffa2