### PR TITLE
Center nav tabs and group bubble

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -12,8 +12,8 @@
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="flex items-center py-4">
-        <a href="index.html" class="flex items-center">
+      <div class="relative flex items-center justify-center py-4">
+        <a href="index.html" class="absolute left-4 top-1/2 -translate-y-1/2 flex items-center">
           <div class="logo-shimmer hover-jiggle">
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
@@ -22,15 +22,13 @@
             <span class="block text-sm">@ William & Mary</span>
           </div>
         </a>
-        <div class="flex-1">
-          <ul class="flex space-x-4 justify-center">
-            <li><a href="index.html" class="nav-tab hover-jiggle no-underline"><span>Home</span></a></li>
-            <li><a href="howwework.html" class="nav-tab hover-jiggle no-underline"><span>Meetings</span></a></li>
-            <li><a href="leadership.html" class="nav-tab hover-jiggle no-underline"><span>Our Team</span></a></li>
-            <li><a href="schedule.html" class="nav-tab hover-jiggle no-underline"><span>Schedule</span></a></li>
-          </ul>
-        </div>
-        <a href="join.html" class="ml-4 hover-jiggle no-underline"><span>Sign Up</span></a>
+        <ul class="nav-tabs space-x-4">
+          <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
+          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
+          <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
+          <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
+        </ul>
+        <a href="join.html" class="hover-jiggle no-underline absolute right-4 top-1/2 -translate-y-1/2"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -12,8 +12,8 @@
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="flex items-center py-4">
-        <a href="index.html" class="flex items-center">
+      <div class="relative flex items-center justify-center py-4">
+        <a href="index.html" class="absolute left-4 top-1/2 -translate-y-1/2 flex items-center">
           <div class="logo-shimmer hover-jiggle">
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
@@ -22,15 +22,13 @@
             <span class="block text-sm">@ William & Mary</span>
           </div>
         </a>
-        <div class="flex-1">
-          <ul class="flex space-x-4 justify-center">
-            <li><a href="index.html" class="nav-tab hover-jiggle no-underline"><span>Home</span></a></li>
-            <li><a href="howwework.html" class="nav-tab hover-jiggle no-underline"><span>Meetings</span></a></li>
-            <li><a href="leadership.html" class="nav-tab hover-jiggle no-underline"><span>Our Team</span></a></li>
-            <li><a href="schedule.html" class="nav-tab hover-jiggle no-underline"><span>Schedule</span></a></li>
-          </ul>
-        </div>
-        <a href="join.html" class="ml-4 hover-jiggle no-underline"><span>Sign Up</span></a>
+        <ul class="nav-tabs space-x-4">
+          <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
+          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
+          <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
+          <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
+        </ul>
+        <a href="join.html" class="hover-jiggle no-underline absolute right-4 top-1/2 -translate-y-1/2"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,8 +20,8 @@
 <body class="flex flex-col min-h-screen">
   <nav class="glass shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="flex items-center py-4">
-        <a href="#home" class="flex items-center">
+      <div class="relative flex items-center justify-center py-4">
+        <a href="#home" class="absolute left-4 top-1/2 -translate-y-1/2 flex items-center">
           <div class="logo-shimmer hover-jiggle">
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
@@ -30,15 +30,13 @@
             <span class="block text-sm">@ William & Mary</span>
           </div>
         </a>
-        <div class="flex-1">
-          <ul class="flex space-x-4 justify-center">
-            <li><a href="#home" class="nav-tab hover-jiggle no-underline"><span>Home</span></a></li>
-            <li><a href="#howwework" class="nav-tab hover-jiggle no-underline"><span>Meetings</span></a></li>
-            <li><a href="#leadership" class="nav-tab hover-jiggle no-underline"><span>Our Team</span></a></li>
-            <li><a href="#schedule" class="nav-tab hover-jiggle no-underline"><span>Schedule</span></a></li>
-          </ul>
-        </div>
-        <a href="#join" class="ml-4 hover-jiggle no-underline"><span>Sign Up</span></a>
+        <ul class="nav-tabs space-x-4">
+          <li><a href="#home" class="hover-jiggle no-underline"><span>Home</span></a></li>
+          <li><a href="#howwework" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
+          <li><a href="#leadership" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
+          <li><a href="#schedule" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
+        </ul>
+        <a href="#join" class="hover-jiggle no-underline absolute right-4 top-1/2 -translate-y-1/2"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/instagram.html
+++ b/docs/instagram.html
@@ -12,8 +12,8 @@
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="flex items-center py-4">
-        <a href="index.html" class="flex items-center">
+      <div class="relative flex items-center justify-center py-4">
+        <a href="index.html" class="absolute left-4 top-1/2 -translate-y-1/2 flex items-center">
           <div class="logo-shimmer hover-jiggle">
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
@@ -22,15 +22,13 @@
             <span class="block text-sm">@ William & Mary</span>
           </div>
         </a>
-        <div class="flex-1">
-          <ul class="flex space-x-4 justify-center">
-            <li><a href="index.html" class="nav-tab hover-jiggle no-underline"><span>Home</span></a></li>
-            <li><a href="howwework.html" class="nav-tab hover-jiggle no-underline"><span>Meetings</span></a></li>
-            <li><a href="leadership.html" class="nav-tab hover-jiggle no-underline"><span>Our Team</span></a></li>
-            <li><a href="schedule.html" class="nav-tab hover-jiggle no-underline"><span>Schedule</span></a></li>
-          </ul>
-        </div>
-        <a href="join.html" class="ml-4 hover-jiggle no-underline"><span>Sign Up</span></a>
+        <ul class="nav-tabs space-x-4">
+          <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
+          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
+          <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
+          <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
+        </ul>
+        <a href="join.html" class="hover-jiggle no-underline absolute right-4 top-1/2 -translate-y-1/2"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/join.html
+++ b/docs/join.html
@@ -12,8 +12,8 @@
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="flex items-center py-4">
-        <a href="index.html" class="flex items-center">
+      <div class="relative flex items-center justify-center py-4">
+        <a href="index.html" class="absolute left-4 top-1/2 -translate-y-1/2 flex items-center">
           <div class="logo-shimmer hover-jiggle">
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
@@ -22,15 +22,13 @@
             <span class="block text-sm">@ William & Mary</span>
           </div>
         </a>
-        <div class="flex-1">
-          <ul class="flex space-x-4 justify-center">
-            <li><a href="index.html" class="nav-tab hover-jiggle no-underline"><span>Home</span></a></li>
-            <li><a href="howwework.html" class="nav-tab hover-jiggle no-underline"><span>Meetings</span></a></li>
-            <li><a href="leadership.html" class="nav-tab hover-jiggle no-underline"><span>Our Team</span></a></li>
-            <li><a href="schedule.html" class="nav-tab hover-jiggle no-underline"><span>Schedule</span></a></li>
-          </ul>
-        </div>
-        <a href="join.html" class="ml-4 hover-jiggle no-underline"><span>Sign Up</span></a>
+        <ul class="nav-tabs space-x-4">
+          <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
+          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
+          <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
+          <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
+        </ul>
+        <a href="join.html" class="hover-jiggle no-underline absolute right-4 top-1/2 -translate-y-1/2"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -12,8 +12,8 @@
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="flex items-center py-4">
-        <a href="index.html" class="flex items-center">
+      <div class="relative flex items-center justify-center py-4">
+        <a href="index.html" class="absolute left-4 top-1/2 -translate-y-1/2 flex items-center">
           <div class="logo-shimmer hover-jiggle">
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
@@ -22,15 +22,13 @@
             <span class="block text-sm">@ William & Mary</span>
           </div>
         </a>
-        <div class="flex-1">
-          <ul class="flex space-x-4 justify-center">
-            <li><a href="index.html" class="nav-tab hover-jiggle no-underline"><span>Home</span></a></li>
-            <li><a href="howwework.html" class="nav-tab hover-jiggle no-underline"><span>Meetings</span></a></li>
-            <li><a href="leadership.html" class="nav-tab hover-jiggle no-underline"><span>Our Team</span></a></li>
-            <li><a href="schedule.html" class="nav-tab hover-jiggle no-underline"><span>Schedule</span></a></li>
-          </ul>
-        </div>
-        <a href="join.html" class="ml-4 hover-jiggle no-underline"><span>Sign Up</span></a>
+        <ul class="nav-tabs space-x-4">
+          <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
+          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
+          <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
+          <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
+        </ul>
+        <a href="join.html" class="hover-jiggle no-underline absolute right-4 top-1/2 -translate-y-1/2"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/schedule.html
+++ b/docs/schedule.html
@@ -12,8 +12,8 @@
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="flex items-center py-4">
-        <a href="index.html" class="flex items-center">
+      <div class="relative flex items-center justify-center py-4">
+        <a href="index.html" class="absolute left-4 top-1/2 -translate-y-1/2 flex items-center">
           <div class="logo-shimmer hover-jiggle">
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
@@ -22,15 +22,13 @@
             <span class="block text-sm">@ William & Mary</span>
           </div>
         </a>
-        <div class="flex-1">
-          <ul class="flex space-x-4 justify-center">
-            <li><a href="index.html" class="nav-tab hover-jiggle no-underline"><span>Home</span></a></li>
-            <li><a href="howwework.html" class="nav-tab hover-jiggle no-underline"><span>Meetings</span></a></li>
-            <li><a href="leadership.html" class="nav-tab hover-jiggle no-underline"><span>Our Team</span></a></li>
-            <li><a href="schedule.html" class="nav-tab hover-jiggle no-underline"><span>Schedule</span></a></li>
-          </ul>
-        </div>
-        <a href="join.html" class="ml-4 hover-jiggle no-underline"><span>Sign Up</span></a>
+        <ul class="nav-tabs space-x-4">
+          <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
+          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
+          <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
+          <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
+        </ul>
+        <a href="join.html" class="hover-jiggle no-underline absolute right-4 top-1/2 -translate-y-1/2"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -12,8 +12,8 @@
 <body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
   <nav class="glass shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="flex items-center py-4">
-        <a href="index.html" class="flex items-center">
+      <div class="relative flex items-center justify-center py-4">
+        <a href="index.html" class="absolute left-4 top-1/2 -translate-y-1/2 flex items-center">
           <div class="logo-shimmer hover-jiggle">
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
@@ -22,15 +22,13 @@
             <span class="block text-sm">@ William & Mary</span>
           </div>
         </a>
-        <div class="flex-1">
-          <ul class="flex space-x-4 justify-center">
-            <li><a href="index.html" class="nav-tab hover-jiggle no-underline"><span>Home</span></a></li>
-            <li><a href="howwework.html" class="nav-tab hover-jiggle no-underline"><span>Meetings</span></a></li>
-            <li><a href="leadership.html" class="nav-tab hover-jiggle no-underline"><span>Our Team</span></a></li>
-            <li><a href="schedule.html" class="nav-tab hover-jiggle no-underline"><span>Schedule</span></a></li>
-          </ul>
-        </div>
-        <a href="join.html" class="ml-4 hover-jiggle no-underline"><span>Sign Up</span></a>
+        <ul class="nav-tabs space-x-4">
+          <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
+          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
+          <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
+          <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
+        </ul>
+        <a href="join.html" class="hover-jiggle no-underline absolute right-4 top-1/2 -translate-y-1/2"><span>Sign Up</span></a>
       </div>
     </div>
   </nav>

--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -26,9 +26,9 @@ nav, nav * {
   font-size: 1.40625rem;
 }
 
-/* Bubble border style for nav tabs */
-.nav-tab {
-  display: inline-block;
+/* Bubble border style for grouped nav tabs */
+.nav-tabs {
+  display: inline-flex;
   border: 1px solid rgba(128, 0, 128, 0.7);
   border-radius: 9999px;
   padding: 0.25rem 0.75rem;


### PR DESCRIPTION
## Summary
- Center navigation tabs across pages and wrap them in a single bordered bubble
- Keep the Sign Up link separate on the right for consistent layout

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6891312c6d1c832dbfb1d4dc09337d5d