### PR TITLE
Center team card descriptions

### DIFF
--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -46,7 +46,7 @@
             <img src="static/assets/images/DSawyer.jpeg" alt="Davis K. Sawyer" class="mx-auto h-40 w-40 object-cover">
             <p class="mt-2 font-semibold text-center">Davis K. Sawyer</p>
             <p class="text-sm text-center whitespace-nowrap">President &amp; Founder</p>
-            <p class="text-sm text-center mb-2">Finance '27</p>
+              <p class="text-sm text-center mb-2 whitespace-nowrap">Finance '27</p>
             <a href="https://www.linkedin.com/in/davis-sawyer-wm2027/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>
@@ -67,8 +67,8 @@
           <div class="card">
             <img src="static/assets/images/IMG_9764 (1) - Edited - Edited.jpg" alt="Daniel R. Butler" class="mx-auto h-40 w-40 object-cover">
             <p class="mt-2 font-semibold text-center">Daniel R. Butler</p>
-            <p class="text-sm text-center">VP, Operations</p>
-            <p class="text-sm text-center">Applied Math '25</p>
+              <p class="text-sm text-center whitespace-nowrap">VP, Operations</p>
+              <p class="text-sm text-center whitespace-nowrap">Applied Math '25</p>
             <p class="text-sm text-center mb-2 whitespace-nowrap">MS Computer Science '27</p>
             <a href="https://www.linkedin.com/in/daniel-butler-a1ba3a296/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
@@ -79,7 +79,7 @@
           <div class="card">
             <img src="static/assets/images/IMG_3556 - Edited.jpg" alt="Tom Chesnut" class="mx-auto h-40 w-40 object-cover">
             <p class="mt-2 font-semibold text-center">Tom G. Chesnut</p>
-            <p class="text-sm text-center">VP, Mentorship</p>
+              <p class="text-sm text-center whitespace-nowrap">VP, Mentorship</p>
             <p class="text-sm text-center mb-2 whitespace-nowrap">History &amp; Religion '27</p>
             <a href="https://www.linkedin.com/in/tom-chesnut-2593a329b/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
@@ -90,8 +90,8 @@
           <div class="card">
             <img src="static/assets/images/Luke Archey-modified - Edited.jpg" alt="Luke X. Archey" class="mx-auto h-40 w-40 object-cover">
             <p class="mt-2 font-semibold text-center">Luke X. Archey</p>
-            <p class="text-sm text-center">VP, Marketing</p>
-            <p class="text-sm text-center mb-2">Economics '26</p>
+              <p class="text-sm text-center whitespace-nowrap">VP, Marketing</p>
+              <p class="text-sm text-center mb-2 whitespace-nowrap">Economics '26</p>
             <a href="https://www.linkedin.com/in/luke-archey-a23668263/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>
@@ -101,8 +101,8 @@
           <div class="card">
             <img src="static/assets/images/IMG_9763 - Edited.jpg" alt="Ben L. Michaud" class="mx-auto h-40 w-40 object-cover">
             <p class="mt-2 font-semibold text-center">Ben L. Michaud</p>
-            <p class="text-sm text-center">VP, Finance</p>
-            <p class="text-sm text-center mb-2">Economics '26</p>
+              <p class="text-sm text-center whitespace-nowrap">VP, Finance</p>
+              <p class="text-sm text-center mb-2 whitespace-nowrap">Economics '26</p>
             <a href="https://www.linkedin.com/in/benmichaud1/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>
@@ -121,8 +121,8 @@
           <div class="card">
             <img src="static/assets/images/297db81b-4a12-4c0b-b739-5fcb7aa892cc.jpg" alt="Audrey P. Sims" class="mx-auto h-40 w-40 object-cover">
             <p class="mt-2 font-semibold text-center">Audrey P. Sims</p>
-            <p class="text-sm text-center">Director, Marketing</p>
-            <p class="text-sm text-center mb-2">Finance '27</p>
+              <p class="text-sm text-center whitespace-nowrap">Director, Marketing</p>
+              <p class="text-sm text-center mb-2 whitespace-nowrap">Finance '27</p>
             <a href="https://www.linkedin.com/in/audreysims" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>
@@ -132,8 +132,8 @@
           <div class="card">
             <img src="static/assets/images/TJander.jpeg" alt="Tristan C. Jander" class="mx-auto h-40 w-40 object-cover">
               <p class="mt-2 font-semibold text-center whitespace-nowrap">Tristan C. Jander</p>
-            <p class="text-sm text-center">Director, Finance</p>
-            <p class="text-sm text-center mb-2">Accounting '27</p>
+              <p class="text-sm text-center whitespace-nowrap">Director, Finance</p>
+              <p class="text-sm text-center mb-2 whitespace-nowrap">Accounting '27</p>
             <a href="https://www.linkedin.com/in/tristan-jander/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>
@@ -144,7 +144,7 @@
             <img src="static/assets/images/AKochell.JPG" alt="Alex R. Kochell" class="mx-auto h-40 w-40 object-cover">
             <p class="mt-2 font-semibold text-center">Alex R. Kochell</p>
               <p class="text-sm text-center whitespace-nowrap">Director, Operations</p>
-            <p class="text-sm text-center mb-2">Finance '27</p>
+              <p class="text-sm text-center mb-2 whitespace-nowrap">Finance '27</p>
             <a href="https://www.linkedin.com/in/alex-kochell-8925492b9/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>

--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -43,7 +43,7 @@
           <div class="card-front flex flex-col">
             <img src="static/assets/images/61e078a2-a487-4882-99f0-f35db1ee22c3.jpg" alt="Alex Johnson" class="mx-auto h-40 w-40 object-cover mb-4">
             <h2 class="text-xl font-semibold">Alex Johnson</h2>
-            <p class="mt-2 text-sm">Senior Analyst, Capital Co.</p>
+              <p class="mt-2 text-sm whitespace-nowrap">Senior Analyst, Capital Co.</p>
           </div>
           <div class="card-back p-4 flex flex-col">
             <p>Alex will share tips on building dynamic models in Excel during this week's meeting.</p>

--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -77,7 +77,7 @@ main h6 {
 
 /* Team card layout */
 .card {
-  width: 200px;
+  width: 256px;
   margin: 1rem auto;
   text-align: center;
   background: transparent;


### PR DESCRIPTION
## Summary
- widen team cards to keep long descriptions centered
- mark all role and program lines as `whitespace-nowrap` to prevent wrapping
- update speaker card to use same no-wrap style

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6891323e5098832d9e5c808dd0aeef20