### PR TITLE
Reduce header logo and title size

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -23,7 +23,12 @@ nav, nav * {
 
 /* Nav title with reduced size */
 .nav-title {
-  font-size: 1.125rem;
+  font-size: 0.84375rem;
+}
+
+/* Logo with reduced height */
+.logo-shimmer img {
+  height: 4.5rem;
 }
 
 /* Bubble border style for grouped nav tabs */


### PR DESCRIPTION
## Summary
- Shrink navigation title font size by 25%
- Reduce logo height by 25% for a smaller header

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6892227c10f0832d9409554f0826e228