### PR TITLE
Unify header title font size

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -19,7 +19,7 @@
           </div>
           <div class="ml-2 hover-jiggle">
             <span class="block nav-title">Financial Modeling Club</span>
-            <span class="block text-sm">@ William & Mary</span>
+            <span class="block nav-title">@ William & Mary</span>
           </div>
         </a>
         <ul class="nav-tabs space-x-4">

--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -19,7 +19,7 @@
           </div>
           <div class="ml-2 hover-jiggle">
             <span class="block nav-title">Financial Modeling Club</span>
-            <span class="block text-sm">@ William & Mary</span>
+            <span class="block nav-title">@ William & Mary</span>
           </div>
         </a>
         <ul class="nav-tabs space-x-4">

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,7 +27,7 @@
           </div>
           <div class="ml-2 hover-jiggle">
             <span class="block nav-title">Financial Modeling Club</span>
-            <span class="block text-sm">@ William & Mary</span>
+            <span class="block nav-title">@ William & Mary</span>
           </div>
         </a>
         <ul class="nav-tabs space-x-4">

--- a/docs/instagram.html
+++ b/docs/instagram.html
@@ -19,7 +19,7 @@
           </div>
           <div class="ml-2 hover-jiggle">
             <span class="block nav-title">Financial Modeling Club</span>
-            <span class="block text-sm">@ William & Mary</span>
+            <span class="block nav-title">@ William & Mary</span>
           </div>
         </a>
         <ul class="nav-tabs space-x-4">

--- a/docs/join.html
+++ b/docs/join.html
@@ -19,7 +19,7 @@
           </div>
           <div class="ml-2 hover-jiggle">
             <span class="block nav-title">Financial Modeling Club</span>
-            <span class="block text-sm">@ William & Mary</span>
+            <span class="block nav-title">@ William & Mary</span>
           </div>
         </a>
         <ul class="nav-tabs space-x-4">

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -19,7 +19,7 @@
           </div>
           <div class="ml-2 hover-jiggle">
             <span class="block nav-title">Financial Modeling Club</span>
-            <span class="block text-sm">@ William & Mary</span>
+            <span class="block nav-title">@ William & Mary</span>
           </div>
         </a>
         <ul class="nav-tabs space-x-4">

--- a/docs/schedule.html
+++ b/docs/schedule.html
@@ -19,7 +19,7 @@
           </div>
           <div class="ml-2 hover-jiggle">
             <span class="block nav-title">Financial Modeling Club</span>
-            <span class="block text-sm">@ William & Mary</span>
+            <span class="block nav-title">@ William & Mary</span>
           </div>
         </a>
         <ul class="nav-tabs space-x-4">

--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -19,7 +19,7 @@
           </div>
           <div class="ml-2 hover-jiggle">
             <span class="block nav-title">Financial Modeling Club</span>
-            <span class="block text-sm">@ William & Mary</span>
+            <span class="block nav-title">@ William & Mary</span>
           </div>
         </a>
         <ul class="nav-tabs space-x-4">


### PR DESCRIPTION
## Summary
- Use shared `nav-title` class for "@ William & Mary" across all pages so the full title displays in one font size

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68922e43e6c4832db0efff29fb500eb5