### PR TITLE
Reorder homepage sections

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -34,13 +34,9 @@
   </nav>
 
   <main class="flex-grow">
-    <section class="flex flex-col items-center justify-center h-64 text-center glass m-4">
-      <h1 class="text-3xl font-bold">Who We Are</h1>
-      <p class="mt-4 max-w-xl">This page offers a closer look at our organization, our roots, and the values that guide our workshops and community activities.</p>
-    </section>
     <section class="py-8 glass m-4">
       <div class="max-w-3xl mx-auto px-4">
-        <h2 class="text-2xl font-bold mb-4 text-center">Background</h2>
+        <h1 class="text-3xl font-bold mb-4 text-center">Background</h1>
         <p>
           The Financial Modeling Club was founded in early 2025 to be a welcoming environment for undergraduate students to learn about modeling and to hone their skills. The club welcomes beginners in modeling, as well as students with substantive experience. William &amp; Mary students come to the club from many different majors. The Executive Board is grateful for the overwhelming faculty support for the club's mission. We will continue to facilitate engagement with alumni and other financial modeling experts both in-person and via video conference to benefit club members.
         </p>

--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -35,14 +35,8 @@
 
   <main class="flex-grow">
     <section class="flex flex-col items-center justify-center h-64 text-center glass m-4">
-      <h1 class="text-3xl font-bold">How We Work</h1>
-      <p class="mt-4 max-w-xl">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-    </section>
-    <section class="py-8 glass m-4">
-      <div class="max-w-3xl mx-auto px-4">
-        <h2 class="text-2xl font-bold mb-4 text-center">Our Process</h2>
-        <p>Our meetings combine interactive workshops with guidance from experienced students and industry professionals, offering members a collaborative space to practice modeling techniques and ask questions.</p>
-      </div>
+      <h1 class="text-3xl font-bold">Meetings</h1>
+      <p class="mt-4 max-w-xl">Our meetings combine interactive workshops with guidance from experienced students and industry professionals, offering members a collaborative space to practice modeling techniques and ask questions.</p>
     </section>
   </main>
 

--- a/docs/static/js/loadSections.js
+++ b/docs/static/js/loadSections.js
@@ -1,12 +1,9 @@
 document.addEventListener('DOMContentLoaded', () => {
   const pages = [
     'about.html',
-    'howwework.html',
     'leadership.html',
-    'schedule.html',
-    'join.html',
-    'speaker.html',
-    'instagram.html'
+    'howwework.html',
+    'speaker.html'
   ];
   const container = document.getElementById('content');
   Promise.all(


### PR DESCRIPTION
## Summary
- Remove unused homepage sections so the landing page follows the requested order.
- Add a dedicated Meetings section.
- Update section loader to include only Background, Executive Board, Directors, Meetings, and Speaker of the Week.

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6892300b7bec832d8fd8672be681601f