### PR TITLE
Restore footer Instagram icon and contact email

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -44,6 +44,17 @@
     </section>
   </main>
 
+  <footer class="glass py-4 text-center">
+    <div class="flex justify-center items-center space-x-4">
+      <a href="mailto:financialmodel@wm.edu" class="text-blue-500 underline hover:no-underline">financialmodel@wm.edu</a>
+      <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
+        <span class="insta-icon logo-shimmer hover-jiggle">
+          <i class="fa-brands fa-instagram text-3xl insta-color"></i>
+        </span>
+      </a>
+    </div>
+  </footer>
+
   <script src="static/js/scripts.js"></script>
 </body>
 </html>

--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -40,6 +40,17 @@
     </section>
   </main>
 
+  <footer class="glass py-4 text-center">
+    <div class="flex justify-center items-center space-x-4">
+      <a href="mailto:financialmodel@wm.edu" class="text-blue-500 underline hover:no-underline">financialmodel@wm.edu</a>
+      <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
+        <span class="insta-icon logo-shimmer hover-jiggle">
+          <i class="fa-brands fa-instagram text-3xl insta-color"></i>
+        </span>
+      </a>
+    </div>
+  </footer>
+
   <script src="static/js/scripts.js"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -53,6 +53,17 @@
     </section>
   </main>
 
+  <footer class="glass py-4 text-center">
+    <div class="flex justify-center items-center space-x-4">
+      <a href="mailto:financialmodel@wm.edu" class="text-blue-500 underline hover:no-underline">financialmodel@wm.edu</a>
+      <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
+        <span class="insta-icon logo-shimmer hover-jiggle">
+          <i class="fa-brands fa-instagram text-3xl insta-color"></i>
+        </span>
+      </a>
+    </div>
+  </footer>
+
   <script type="module" src="static/js/waveBackground.js"></script>
   <script src="static/js/scripts.js"></script>
   <script src="static/js/loadSections.js"></script>

--- a/docs/instagram.html
+++ b/docs/instagram.html
@@ -38,7 +38,7 @@
       <div class="-mx-4">
         <p class="mt-3 text-center">
           <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram" class="inline-block">
-            <span class="insta-icon">
+            <span class="insta-icon logo-shimmer hover-jiggle">
               <i class="fa-brands fa-instagram text-5xl insta-color"></i>
             </span>
           </a>
@@ -46,6 +46,17 @@
       </div>
     </section>
   </main>
+
+  <footer class="glass py-4 text-center">
+    <div class="flex justify-center items-center space-x-4">
+      <a href="mailto:financialmodel@wm.edu" class="text-blue-500 underline hover:no-underline">financialmodel@wm.edu</a>
+      <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
+        <span class="insta-icon logo-shimmer hover-jiggle">
+          <i class="fa-brands fa-instagram text-3xl insta-color"></i>
+        </span>
+      </a>
+    </div>
+  </footer>
 
   <script src="static/js/scripts.js"></script>
 </body>

--- a/docs/join.html
+++ b/docs/join.html
@@ -43,6 +43,17 @@
     </section>
   </main>
 
+  <footer class="glass py-4 text-center">
+    <div class="flex justify-center items-center space-x-4">
+      <a href="mailto:financialmodel@wm.edu" class="text-blue-500 underline hover:no-underline">financialmodel@wm.edu</a>
+      <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
+        <span class="insta-icon logo-shimmer hover-jiggle">
+          <i class="fa-brands fa-instagram text-3xl insta-color"></i>
+        </span>
+      </a>
+    </div>
+  </footer>
+
   <script src="static/js/scripts.js"></script>
 </body>
 </html>

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -153,6 +153,17 @@
     </section>
   </main>
 
+  <footer class="glass py-4 text-center">
+    <div class="flex justify-center items-center space-x-4">
+      <a href="mailto:financialmodel@wm.edu" class="text-blue-500 underline hover:no-underline">financialmodel@wm.edu</a>
+      <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
+        <span class="insta-icon logo-shimmer hover-jiggle">
+          <i class="fa-brands fa-instagram text-3xl insta-color"></i>
+        </span>
+      </a>
+    </div>
+  </footer>
+
   <script src="static/js/scripts.js"></script>
 </body>
 </html>

--- a/docs/schedule.html
+++ b/docs/schedule.html
@@ -38,6 +38,17 @@
     <ul id="events-list" class="max-w-xl mx-auto"></ul>
   </main>
 
+  <footer class="glass py-4 text-center">
+    <div class="flex justify-center items-center space-x-4">
+      <a href="mailto:financialmodel@wm.edu" class="text-blue-500 underline hover:no-underline">financialmodel@wm.edu</a>
+      <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
+        <span class="insta-icon logo-shimmer hover-jiggle">
+          <i class="fa-brands fa-instagram text-3xl insta-color"></i>
+        </span>
+      </a>
+    </div>
+  </footer>
+
   <script src="static/js/scripts.js"></script>
 </body>
 </html>

--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -51,6 +51,17 @@
     </section>
   </main>
 
+  <footer class="glass py-4 text-center">
+    <div class="flex justify-center items-center space-x-4">
+      <a href="mailto:financialmodel@wm.edu" class="text-blue-500 underline hover:no-underline">financialmodel@wm.edu</a>
+      <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
+        <span class="insta-icon logo-shimmer hover-jiggle">
+          <i class="fa-brands fa-instagram text-3xl insta-color"></i>
+        </span>
+      </a>
+    </div>
+  </footer>
+
   <script src="static/js/scripts.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add site-wide footer with animated Instagram icon and blue contact email link
- Style email link to remove underline on hover

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68923d31d7e8832db93c05de46efe6f4