### PR TITLE
Add Benjamin Monforth director card

### DIFF
--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -149,6 +149,12 @@
               </span>
             </a>
           </div>
+          <div class="card">
+            <img src="static/assets/images/eb09a524-9146-4e54-8275-166d4b9ee4d9 (1).jpg" alt="Benjamin M. Monforth" class="mx-auto h-40 w-40 object-cover">
+            <p class="mt-2 font-semibold text-center whitespace-nowrap">Benjamin M. Monforth</p>
+            <p class="text-sm text-center whitespace-nowrap">Director, Corporate Relations</p>
+            <p class="text-sm text-center mb-2 whitespace-nowrap">Physics '26</p>
+          </div>
         </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- add Benjamin M. Monforth to directors team grid with centered, non-wrapping text

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68923df56f60832d8be907691106a26d