### PR TITLE
Add LinkedIn link for Benjamin Monforth

### DIFF
--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -154,6 +154,11 @@
             <p class="mt-2 font-semibold text-center whitespace-nowrap">Benjamin M. Monforth</p>
             <p class="text-sm text-center whitespace-nowrap">Director, Corporate Relations</p>
             <p class="text-sm text-center mb-2 whitespace-nowrap">Physics '26</p>
+            <a href="https://www.linkedin.com/in/benjamin-monforth2026/" target="_blank" class="block text-center mt-2">
+              <span class="linkedin-icon">
+                <i class="fab fa-linkedin fa-2x linkedin-color"></i>
+              </span>
+            </a>
           </div>
         </div>
     </section>


### PR DESCRIPTION
## Summary
- add Benjamin Monforth's LinkedIn profile with standard icon to directors section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6892400bab4c832dbf39ab62ff6a4e29