### PR TITLE
Center speaker details below image

### DIFF
--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -40,8 +40,8 @@
         <div class="card-inner">
           <div class="card-front flex flex-col">
             <img src="static/assets/images/61e078a2-a487-4882-99f0-f35db1ee22c3.jpg" alt="Thomas C. Sawyer" class="mx-auto h-40 w-40 object-cover mb-4">
-            <h2 class="text-xl font-semibold text-center whitespace-nowrap">Thomas C. Sawyer</h2>
-            <p class="mt-2 text-sm whitespace-nowrap text-center">Investment Banking Associate at Piper Sandler</p>
+            <h2 class="text-xl font-semibold text-center whitespace-nowrap w-40 mx-auto">Thomas C. Sawyer</h2>
+            <p class="mt-2 text-sm whitespace-nowrap text-center w-40 mx-auto">Investment Banking Associate at Piper Sandler</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Align speaker name and title directly beneath the headshot with consistent width

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/FMC-W-M/package.json')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689245a63b90832da014c86580ce6974