### PR TITLE
Center speaker details under section header

### DIFF
--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -40,8 +40,8 @@
         <div class="card-inner">
           <div class="card-front flex flex-col">
             <img src="static/assets/images/61e078a2-a487-4882-99f0-f35db1ee22c3.jpg" alt="Thomas C. Sawyer" class="mx-auto h-40 w-40 object-cover mb-4">
-            <h2 class="text-xl font-semibold text-center whitespace-nowrap w-fit mx-auto">Thomas C. Sawyer</h2>
-            <p class="mt-2 text-sm whitespace-nowrap text-center w-fit mx-auto">Investment Banking Associate at Piper Sandler</p>
+              <h2 class="text-xl font-semibold text-center">Thomas C. Sawyer</h2>
+              <p class="mt-2 text-sm text-center">Investment Banking Associate<br>at Piper Sandler</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Align "Thomas C. Sawyer" and the accompanying job title with section headers by removing width constraints and centering text.
- Break long job title into two centered lines for improved readability.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68924f6836b0832db75a3989355f0939