### PR TITLE
Replace 'Speaker of the Week' with 'Our Next Speaker'

### DIFF
--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Speaker of the Week – Financial Modeling Club at William & Mary</title>
+  <title>Our Next Speaker – Financial Modeling Club at William & Mary</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css" rel="stylesheet">
   <link href="static/css/glass.css" rel="stylesheet">
@@ -35,7 +35,7 @@
 
   <main class="flex-grow py-8 glass m-4">
     <section class="max-w-3xl mx-auto px-4 text-center">
-      <h1 class="text-3xl font-bold mb-4">Speaker of the Week</h1>
+      <h1 class="text-3xl font-bold mb-4">Our Next Speaker</h1>
       <div class="card">
         <div class="card-inner">
           <div class="card-front flex flex-col">


### PR DESCRIPTION
## Summary
- rename page title and heading from "Speaker of the Week" to "Our Next Speaker" for consistency

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68925363140c832daf0e4af2a68a637c