### PR TITLE
Remove centering from Background description

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -36,7 +36,7 @@
   <main class="flex-grow">
     <section class="py-8 glass m-4">
       <div class="max-w-3xl mx-auto px-4">
-        <h1 class="text-3xl font-bold mb-4 text-center">Background</h1>
+        <h1 class="text-3xl font-bold mb-4">Background</h1>
         <p>
           The Financial Modeling Club was founded in early 2025 to be a welcoming environment for undergraduate students to learn about modeling and to hone their skills. The club welcomes beginners in modeling, as well as students with substantive experience. William &amp; Mary students come to the club from many different majors. The Executive Board is grateful for the overwhelming faculty support for the club's mission. We will continue to facilitate engagement with alumni and other financial modeling experts both in-person and via video conference to benefit club members.
         </p>


### PR DESCRIPTION
## Summary
- Align Background heading on About page with other sections by removing centering class

## Testing
- `npx htmlhint docs/about.html` *(fails: 403 Forbidden)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6892541c6fa4832dbba11a7504951590