### PR TITLE
Fix Background description alignment

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -37,7 +37,7 @@
     <section class="py-8 glass m-4">
       <div class="max-w-3xl mx-auto px-4">
         <h1 class="text-3xl font-bold mb-4 text-center">Background</h1>
-        <p>
+        <p class="text-left">
           The Financial Modeling Club was founded in early 2025 to be a welcoming environment for undergraduate students to learn about modeling and to hone their skills. The club welcomes beginners in modeling, as well as students with substantive experience. William &amp; Mary students come to the club from many different majors. The Executive Board is grateful for the overwhelming faculty support for the club's mission. We will continue to facilitate engagement with alumni and other financial modeling experts both in-person and via video conference to benefit club members.
         </p>
       </div>


### PR DESCRIPTION
## Summary
- keep the Background heading centered
- align the Background section's description with other sections

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689255c77210832db5cc35bf5682089a