### PR TITLE
Adjust speaker text alignment

### DIFF
--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -40,8 +40,8 @@
         <div class="card-inner">
           <div class="card-front flex flex-col">
             <img src="static/assets/images/61e078a2-a487-4882-99f0-f35db1ee22c3.jpg" alt="Thomas C. Sawyer" class="mx-auto h-40 w-40 object-cover mb-4">
-            <h2 class="text-xl font-semibold text-center whitespace-nowrap w-fit mx-auto">Thomas C. Sawyer</h2>
-            <p class="mt-2 text-sm whitespace-nowrap text-center w-fit mx-auto">Investment Banking Associate at Piper Sandler</p>
+            <h2 class="text-xl font-semibold whitespace-nowrap ml-24 text-left">Thomas C. Sawyer</h2>
+            <p class="mt-2 text-sm whitespace-nowrap ml-24 text-left">Investment Banking Associate at Piper Sandler</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Shift speaker name and title left by 1 inch using Tailwind margin classes

## Testing
- `npm test` (fails: ENOENT, missing package.json)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6892565cfcb0832dbcad95c01984bacf