### PR TITLE
Refine Meetings section layout

### DIFF
--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -34,12 +34,12 @@
   </nav>
 
   <main class="flex-grow">
-    <section class="flex flex-col items-center justify-center h-64 text-center glass m-4">
-      <h1 class="text-3xl font-bold">Meetings</h1>
-      <ol class="mt-4 max-w-xl text-left list-decimal list-inside">
-        <li>Every meeting, we host a guest speaker with expertise in financial modeling who answers questions and provides valuable insights to help prepare students for success in finance.</li>
-        <li>Following the speakers, we guide members through interactive workshops with practice models and slide show presentations to build a solid foundation in financial modeling.</li>
-      </ol>
+    <section class="py-8 glass m-4">
+      <div class="max-w-3xl mx-auto px-4">
+        <h1 class="text-3xl font-bold mb-4 text-center">Meetings</h1>
+        <p>Every meeting, we host a guest speaker with expertise in financial modeling who answers questions and provides valuable insights to help prepare students for success in finance.</p>
+        <p class="mt-4">Following the speakers, we guide members through interactive workshops with practice models and slide show presentations to build a solid foundation in financial modeling.</p>
+      </div>
     </section>
   </main>
 


### PR DESCRIPTION
## Summary
- realign Meetings section description to match other pages
- retain centered "Meetings" header while left-aligning description text with added spacing

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/FMC-W-M/package.json')*

------
https://chatgpt.com/codex/tasks/task_b_68925623ee54832d9d0c463bf568b015