### PR TITLE
Remove blinking cursor after section headers

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -137,21 +137,6 @@ main h6 {
   opacity: 1;
 }
 
-/* Blinking cursor for typed headings */
-.cursor {
-  display: inline-block;
-  animation: blink 1s steps(2, start) infinite;
-}
-
-@keyframes blink {
-  0%, 50% {
-    opacity: 1;
-  }
-  50%, 100% {
-    opacity: 0;
-  }
-}
-
 /* Shimmer effect for logo */
 .logo-shimmer {
   position: relative;

--- a/docs/static/js/scripts.js
+++ b/docs/static/js/scripts.js
@@ -128,18 +128,12 @@ function initFMC() {
 
 function typeText(el, text, speed) {
   el.textContent = '';
-  const isHeading = /^H[1-6]$/.test(el.tagName);
   let idx = 0;
 
   function typeNext() {
     if (idx < text.length) {
       el.textContent += text[idx++];
       setTimeout(typeNext, speed);
-    } else if (isHeading) {
-      const cursor = document.createElement('span');
-      cursor.className = 'cursor';
-      cursor.textContent = '_';
-      el.appendChild(cursor);
     }
   }
 


### PR DESCRIPTION
## Summary
- remove JavaScript that added a blinking cursor after headings
- drop unused cursor animation styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689260b3c768832da56d6c8cde3f423b