### PR TITLE
Left-align meeting descriptions

### DIFF
--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -35,10 +35,10 @@
 
   <main class="flex-grow">
     <section class="py-8 glass m-4">
-      <div class="max-w-3xl mx-auto px-4">
+      <div class="max-w-3xl mx-auto">
         <h1 class="text-3xl font-bold mb-4 text-center">Meetings</h1>
-        <p>Every meeting, we host a guest speaker with expertise in financial modeling who answers questions and provides valuable insights to help prepare students for success in finance.</p>
-        <p class="mt-4">Following the speakers, we guide members through interactive workshops with practice models and slide show presentations to build a solid foundation in financial modeling.</p>
+        <p class="text-left">Every meeting, we host a guest speaker with expertise in financial modeling who answers questions and provides valuable insights to help prepare students for success in finance.</p>
+        <p class="mt-4 text-left">Following the speakers, we guide members through interactive workshops with practice models and slide show presentations to build a solid foundation in financial modeling.</p>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- Remove inner padding on the meetings page so descriptive text sits flush against the text box edges.
- Explicitly left-align meeting descriptions for consistent layout.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6892602050d0832d8ffc783340373c7e