### PR TITLE
Swap Meetings and Our Team nav tabs

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -24,8 +24,8 @@
         </a>
         <ul class="nav-tabs space-x-4">
           <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
-          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
+          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
           <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
         </ul>
         <a href="https://forms.gle/g9i47Hh5tsbSpKV19" class="hover-jiggle no-underline absolute right-4 top-1/2 -translate-y-1/2"><span>Sign Up</span></a>

--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -24,8 +24,8 @@
         </a>
         <ul class="nav-tabs space-x-4">
           <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
-          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
+          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
           <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
         </ul>
         <a href="https://forms.gle/g9i47Hh5tsbSpKV19" class="hover-jiggle no-underline absolute right-4 top-1/2 -translate-y-1/2"><span>Sign Up</span></a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -32,8 +32,8 @@
         </a>
         <ul class="nav-tabs space-x-4">
           <li><a href="#home" class="hover-jiggle no-underline"><span>Home</span></a></li>
-          <li><a href="#howwework" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
           <li><a href="#leadership" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
+          <li><a href="#howwework" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
           <li><a href="#schedule" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
         </ul>
         <a href="https://forms.gle/g9i47Hh5tsbSpKV19" class="hover-jiggle no-underline absolute right-4 top-1/2 -translate-y-1/2"><span>Sign Up</span></a>

--- a/docs/instagram.html
+++ b/docs/instagram.html
@@ -24,8 +24,8 @@
         </a>
         <ul class="nav-tabs space-x-4">
           <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
-          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
+          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
           <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
         </ul>
         <a href="https://forms.gle/g9i47Hh5tsbSpKV19" class="hover-jiggle no-underline absolute right-4 top-1/2 -translate-y-1/2"><span>Sign Up</span></a>

--- a/docs/join.html
+++ b/docs/join.html
@@ -24,8 +24,8 @@
         </a>
         <ul class="nav-tabs space-x-4">
           <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
-          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
+          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
           <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
         </ul>
         <a href="https://forms.gle/g9i47Hh5tsbSpKV19" class="hover-jiggle no-underline absolute right-4 top-1/2 -translate-y-1/2"><span>Sign Up</span></a>

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -24,8 +24,8 @@
         </a>
         <ul class="nav-tabs space-x-4">
           <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
-          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
+          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
           <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
         </ul>
         <a href="https://forms.gle/g9i47Hh5tsbSpKV19" class="hover-jiggle no-underline absolute right-4 top-1/2 -translate-y-1/2"><span>Sign Up</span></a>

--- a/docs/schedule.html
+++ b/docs/schedule.html
@@ -24,8 +24,8 @@
         </a>
         <ul class="nav-tabs space-x-4">
           <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
-          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
+          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
           <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
         </ul>
         <a href="https://forms.gle/g9i47Hh5tsbSpKV19" class="hover-jiggle no-underline absolute right-4 top-1/2 -translate-y-1/2"><span>Sign Up</span></a>

--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -24,8 +24,8 @@
         </a>
         <ul class="nav-tabs space-x-4">
           <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
-          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
           <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
+          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
           <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
         </ul>
         <a href="https://forms.gle/g9i47Hh5tsbSpKV19" class="hover-jiggle no-underline absolute right-4 top-1/2 -translate-y-1/2"><span>Sign Up</span></a>


### PR DESCRIPTION
## Summary
- Reorder nav bar tabs so Our Team appears before Meetings across all pages.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6892693b5354832db7c2aaddca05c435