### PR TITLE
Embed Google Calendar on schedule page

### DIFF
--- a/docs/schedule.html
+++ b/docs/schedule.html
@@ -38,6 +38,9 @@
   <main class="flex-grow py-8 glass m-4">
     <h1 class="text-3xl font-bold mb-4 text-center">Upcoming Events</h1>
     <ul id="events-list" class="max-w-xl mx-auto"></ul>
+    <div class="max-w-4xl mx-auto mt-8">
+      <iframe src="https://calendar.google.com/calendar/embed?src=aa3e8ef9cbda489545ecfcc3ae5daee0e2b0aaf5cfbd6211699381c04be035c8%40group.calendar.google.com&amp;ctz=America%2FNew_York" style="border:0" width="100%" height="600" frameborder="0" scrolling="no"></iframe>
+    </div>
   </main>
 
   <footer class="glass py-4 text-center">


### PR DESCRIPTION
## Summary
- show Google Calendar with club events on the schedule page

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68926da09ec4832d920ab0a5107bab2f