### PR TITLE
Link schedule tab to Google Calendar

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -26,7 +26,7 @@
           <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
           <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
           <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
-          <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
+          <li><a href="https://calendar.google.com/calendar/embed?src=aa3e8ef9cbda489545ecfcc3ae5daee0e2b0aaf5cfbd6211699381c04be035c8%40group.calendar.google.com&amp;ctz=America%2FNew_York" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
         </ul>
         <div class="absolute right-4 top-1/2 -translate-y-1/2">
           <a href="https://forms.gle/g9i47Hh5tsbSpKV19" class="hover-jiggle no-underline"><span>Sign Up</span></a>

--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -26,7 +26,7 @@
           <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
           <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
           <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
-          <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
+          <li><a href="https://calendar.google.com/calendar/embed?src=aa3e8ef9cbda489545ecfcc3ae5daee0e2b0aaf5cfbd6211699381c04be035c8%40group.calendar.google.com&amp;ctz=America%2FNew_York" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
         </ul>
         <div class="absolute right-4 top-1/2 -translate-y-1/2">
           <a href="https://forms.gle/g9i47Hh5tsbSpKV19" class="hover-jiggle no-underline"><span>Sign Up</span></a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -34,7 +34,7 @@
           <li><a href="#home" class="hover-jiggle no-underline"><span>Home</span></a></li>
           <li><a href="#leadership" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
           <li><a href="#howwework" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
-          <li><a href="#schedule" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
+          <li><a href="https://calendar.google.com/calendar/embed?src=aa3e8ef9cbda489545ecfcc3ae5daee0e2b0aaf5cfbd6211699381c04be035c8%40group.calendar.google.com&amp;ctz=America%2FNew_York" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
         </ul>
         <div class="absolute right-4 top-1/2 -translate-y-1/2">
           <a href="https://forms.gle/g9i47Hh5tsbSpKV19" class="hover-jiggle no-underline"><span>Sign Up</span></a>

--- a/docs/instagram.html
+++ b/docs/instagram.html
@@ -26,7 +26,7 @@
           <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
           <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
           <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
-          <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
+          <li><a href="https://calendar.google.com/calendar/embed?src=aa3e8ef9cbda489545ecfcc3ae5daee0e2b0aaf5cfbd6211699381c04be035c8%40group.calendar.google.com&amp;ctz=America%2FNew_York" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
         </ul>
         <div class="absolute right-4 top-1/2 -translate-y-1/2">
           <a href="https://forms.gle/g9i47Hh5tsbSpKV19" class="hover-jiggle no-underline"><span>Sign Up</span></a>

--- a/docs/join.html
+++ b/docs/join.html
@@ -26,7 +26,7 @@
           <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
           <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
           <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
-          <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
+          <li><a href="https://calendar.google.com/calendar/embed?src=aa3e8ef9cbda489545ecfcc3ae5daee0e2b0aaf5cfbd6211699381c04be035c8%40group.calendar.google.com&amp;ctz=America%2FNew_York" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
         </ul>
         <div class="absolute right-4 top-1/2 -translate-y-1/2">
           <a href="https://forms.gle/g9i47Hh5tsbSpKV19" class="hover-jiggle no-underline"><span>Sign Up</span></a>

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -26,7 +26,7 @@
           <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
           <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
           <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
-          <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
+          <li><a href="https://calendar.google.com/calendar/embed?src=aa3e8ef9cbda489545ecfcc3ae5daee0e2b0aaf5cfbd6211699381c04be035c8%40group.calendar.google.com&amp;ctz=America%2FNew_York" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
         </ul>
         <div class="absolute right-4 top-1/2 -translate-y-1/2">
           <a href="https://forms.gle/g9i47Hh5tsbSpKV19" class="hover-jiggle no-underline"><span>Sign Up</span></a>

--- a/docs/schedule.html
+++ b/docs/schedule.html
@@ -26,7 +26,7 @@
           <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
           <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
           <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
-          <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
+          <li><a href="https://calendar.google.com/calendar/embed?src=aa3e8ef9cbda489545ecfcc3ae5daee0e2b0aaf5cfbd6211699381c04be035c8%40group.calendar.google.com&amp;ctz=America%2FNew_York" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
         </ul>
         <div class="absolute right-4 top-1/2 -translate-y-1/2">
           <a href="https://forms.gle/g9i47Hh5tsbSpKV19" class="hover-jiggle no-underline"><span>Sign Up</span></a>

--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -26,7 +26,7 @@
           <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
           <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
           <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
-          <li><a href="schedule.html" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
+          <li><a href="https://calendar.google.com/calendar/embed?src=aa3e8ef9cbda489545ecfcc3ae5daee0e2b0aaf5cfbd6211699381c04be035c8%40group.calendar.google.com&amp;ctz=America%2FNew_York" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
         </ul>
         <div class="absolute right-4 top-1/2 -translate-y-1/2">
           <a href="https://forms.gle/g9i47Hh5tsbSpKV19" class="hover-jiggle no-underline"><span>Sign Up</span></a>


### PR DESCRIPTION
## Summary
- Link the navigation bar's Schedule tab to the club Google Calendar across all pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689271089064832d910d1316f6e594cb