### PR TITLE
Center speaker name on page

### DIFF
--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -42,8 +42,8 @@
         <div class="card-inner">
           <div class="card-front flex flex-col">
             <img src="static/assets/images/61e078a2-a487-4882-99f0-f35db1ee22c3.jpg" alt="Thomas C. Sawyer" class="mx-auto h-40 w-40 object-cover mb-4">
-            <h2 class="text-xl font-semibold whitespace-nowrap ml-24 text-left">Thomas C. Sawyer</h2>
-            <p class="mt-2 text-sm whitespace-nowrap ml-24 text-left">Investment Banking Associate at Piper Sandler</p>
+            <h2 class="text-xl font-semibold whitespace-nowrap text-center">Thomas C. Sawyer</h2>
+            <p class="mt-2 text-sm whitespace-nowrap text-center">Investment Banking Associate at Piper Sandler</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Center speaker name and job title with Tailwind classes to avoid wrapping and shift left margin

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6892755ed750832db693c371e86004c6