### PR TITLE
feat: center align speaker role

### DIFF
--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -43,7 +43,7 @@
           <div class="card-front flex flex-col">
             <img src="static/assets/images/61e078a2-a487-4882-99f0-f35db1ee22c3.jpg" alt="Thomas C. Sawyer" class="mx-auto h-40 w-40 object-cover mb-4">
             <h2 class="text-xl font-semibold whitespace-nowrap ml-24 text-left">Thomas C. Sawyer</h2>
-            <p class="mt-2 text-sm whitespace-nowrap ml-24 text-left">Investment Banking Associate at Piper Sandler</p>
+            <p class="mt-2 text-sm whitespace-nowrap text-center">Investment Banking Associate at Piper Sandler</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- center the "Investment Banking Associate at Piper Sandler" role text on the speaker page to avoid wrapping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6892763f1e94832da01f16c38e0060df