### PR TITLE
Prevent intro message text wrapping

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -44,6 +44,10 @@ body * {
   color: var(--openai-white) !important;
 }
 
+#intro-message {
+  white-space: nowrap;
+}
+
 /* Uniform section header sizing to match "Who We Are" */
 main h1,
 main h2,


### PR DESCRIPTION
## Summary
- keep the homepage's intro tagline on a single line by preventing text wrapping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689275b9d098832d95196e96c69f790c