### PR TITLE
Align meeting description to the left

### DIFF
--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -37,10 +37,10 @@
 
   <main class="flex-grow">
     <section class="py-8 glass m-4">
-      <div class="max-w-3xl mx-auto">
+      <div class="max-w-3xl text-left">
         <h1 class="text-3xl font-bold mb-4 text-center">Meetings</h1>
-        <p class="text-left">Every meeting, we host a guest speaker with expertise in financial modeling who answers questions and provides valuable insights to help prepare students for success in finance.</p>
-        <p class="mt-4 text-left">Following the speakers, we guide members through interactive workshops with practice models and slide show presentations to build a solid foundation in financial modeling.</p>
+        <p>Every meeting, we host a guest speaker with expertise in financial modeling who answers questions and provides valuable insights to help prepare students for success in finance.</p>
+        <p class="mt-4">Following the speakers, we guide members through interactive workshops with practice models and slide show presentations to build a solid foundation in financial modeling.</p>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- left-align meeting description text on the Meetings page

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_b_6892761283b4832dbe1437d6bb532058