### PR TITLE
Center align speaker page elements

### DIFF
--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -37,11 +37,11 @@
 
   <main class="flex-grow py-8 glass m-4">
     <section class="max-w-3xl mx-auto px-4 text-center">
-      <h1 class="text-3xl font-bold mb-4">Our Next Speaker</h1>
+      <h1 class="text-3xl font-bold mb-4 text-center whitespace-nowrap">Our Next Speaker</h1>
       <div class="card">
         <div class="card-inner">
-          <div class="card-front flex flex-col">
-            <img src="static/assets/images/61e078a2-a487-4882-99f0-f35db1ee22c3.jpg" alt="Thomas C. Sawyer" class="mx-auto h-40 w-40 object-cover mb-4">
+          <div class="card-front flex flex-col items-center">
+            <img src="static/assets/images/61e078a2-a487-4882-99f0-f35db1ee22c3.jpg" alt="Thomas C. Sawyer" class="mx-auto h-40 w-40 object-cover mb-4 block">
             <h2 class="text-xl font-semibold whitespace-nowrap text-center">Thomas C. Sawyer</h2>
             <p class="mt-2 text-sm whitespace-nowrap text-center">Investment Banking Associate at Piper Sandler</p>
           </div>


### PR DESCRIPTION
## Summary
- Centered "Our Next Speaker" heading and ensured no wrapping
- Ensured speaker image and job title are centered with no text wrapping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68927a6887f8832d8eea1b52acecdf49