### PR TITLE
Center align Background and Meetings section headers

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -37,7 +37,7 @@
 
   <main class="flex-grow">
     <section class="py-8 glass m-4">
-      <div class="max-w-3xl px-4">
+      <div class="max-w-3xl px-4 mx-auto">
         <h1 class="text-3xl font-bold mb-4 text-center">Background</h1>
         <p class="text-left" style="text-align: left;">
           The Financial Modeling Club was founded in early 2025 to be a welcoming environment for undergraduate students to learn about modeling and to hone their skills. The club welcomes beginners in modeling, as well as students with substantive experience. William &amp; Mary students come to the club from many different majors. The Executive Board is grateful for the overwhelming faculty support for the club's mission. We will continue to facilitate engagement with alumni and other financial modeling experts both in-person and via video conference to benefit club members.

--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -37,7 +37,7 @@
 
   <main class="flex-grow">
     <section class="py-8 glass m-4">
-      <div class="max-w-3xl text-left">
+      <div class="max-w-3xl text-left mx-auto">
         <h1 class="text-3xl font-bold mb-4 text-center">Meetings</h1>
         <p>Every meeting, we host a guest speaker with expertise in financial modeling who answers questions and provides valuable insights to help prepare students for success in finance.</p>
         <p class="mt-4">Following the speakers, we guide members through interactive workshops with practice models and slide show presentations to build a solid foundation in financial modeling.</p>


### PR DESCRIPTION
## Summary
- ensure Background and Meetings sections display centered by adding automatic horizontal margins

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68927a8eb810832da9df757831fe89f5