### PR TITLE
Align meeting description text

### DIFF
--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -39,8 +39,8 @@
     <section class="py-8 glass m-4">
       <div class="max-w-3xl text-left">
         <h1 class="text-3xl font-bold mb-4 text-center">Meetings</h1>
-        <p>Every meeting, we host a guest speaker with expertise in financial modeling who answers questions and provides valuable insights to help prepare students for success in finance.</p>
-        <p class="mt-4">Following the speakers, we guide members through interactive workshops with practice models and slide show presentations to build a solid foundation in financial modeling.</p>
+        <p class="mb-8 text-left">Every meeting, we host a guest speaker with expertise in financial modeling who answers questions and provides valuable insights to help prepare students for success in finance.</p>
+        <p class="mb-8 text-left">Following the speakers, we guide members through interactive workshops with practice models and slide show presentations to build a solid foundation in financial modeling.</p>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- ensure meeting paragraphs use same left-aligned style as directors section

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68927b5bf50c832dad93478f19aef8bf