### PR TITLE
Adjust section spacing and center director title

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -36,7 +36,7 @@
   </nav>
 
   <main class="flex-grow">
-    <section class="py-8 glass m-4">
+    <section class="py-8 glass mx-4 mb-4 mt-0">
       <div class="max-w-3xl px-4 mx-auto">
         <h1 class="text-3xl font-bold mb-4 text-center">Background</h1>
         <p class="text-left" style="text-align: left;">

--- a/docs/index.html
+++ b/docs/index.html
@@ -44,7 +44,7 @@
   </nav>
 
   <main class="flex-grow" id="content">
-    <section id="home" class="p-4 glass">
+    <section id="home" class="p-4 pt-0 glass">
       <section class="text-center py-3">
         <div class="max-w-4xl mx-auto">
           <h1 class="text-2xl font-bold text-gray-700">Welcome to the Financial Modeling Club</h1>

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -165,7 +165,7 @@
           <div class="card">
             <img src="static/assets/images/eb09a524-9146-4e54-8275-166d4b9ee4d9 (1).jpg" alt="Benjamin M. Monforth" class="mx-auto h-40 w-40 object-cover">
             <p class="mt-2 font-semibold text-center whitespace-nowrap">Benjamin M. Monforth</p>
-            <p class="text-sm text-center whitespace-nowrap w-fit mx-auto">Director, Corporate Relations</p>
+            <p class="text-sm text-center whitespace-nowrap">Director, Corporate Relations</p>
             <p class="text-sm text-center mb-2 whitespace-nowrap">Physics '26</p>
             <a href="https://www.linkedin.com/in/benjamin-monforth2026/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">


### PR DESCRIPTION
## Summary
- Reduce top padding on the home page's welcome section for a tighter fit beneath the navigation bar
- Trim top margin on the About page background section to match spacing change
- Center align Benjamin Monforth's "Director, Corporate Relations" title with no wrapping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68927f503288832dbc63b7b28faaaf23