### PR TITLE
Align Thomas C. Sawyer name styling with leadership format

### DIFF
--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -42,7 +42,7 @@
         <div class="card-inner">
           <div class="card-front flex flex-col items-center">
             <img src="static/assets/images/61e078a2-a487-4882-99f0-f35db1ee22c3.jpg" alt="Thomas C. Sawyer" class="mx-auto h-40 w-40 object-cover mb-4 block">
-            <h2 class="text-xl font-semibold whitespace-nowrap text-center">Thomas C. Sawyer</h2>
+            <p class="mt-2 font-semibold text-center whitespace-nowrap">Thomas C. Sawyer</p>
             <p class="mt-2 text-sm whitespace-nowrap text-center">Investment Banking Associate at Piper Sandler</p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Ensure Thomas C. Sawyer's name matches the font and size of Tristan C. Jander in the site markup

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6892804a1b44832da2e37006a520b174