### PR TITLE
Hide executive board when home tab selected

### DIFF
--- a/docs/static/js/loadSections.js
+++ b/docs/static/js/loadSections.js
@@ -35,5 +35,8 @@ document.addEventListener('DOMContentLoaded', () => {
     if (window.initFMC) {
       window.initFMC();
     }
+    if (window.showSection) {
+      window.showSection('home');
+    }
   });
 });

--- a/docs/static/js/scripts.js
+++ b/docs/static/js/scripts.js
@@ -1,3 +1,22 @@
+function showSection(targetId) {
+  const sections = document.querySelectorAll('#content > section');
+  sections.forEach(sec => {
+    if (targetId === 'home') {
+      if (sec.id === 'home' || sec.id === 'about') {
+        sec.classList.remove('hidden');
+      } else {
+        sec.classList.add('hidden');
+      }
+    } else {
+      if (sec.id === targetId) {
+        sec.classList.remove('hidden');
+      } else {
+        sec.classList.add('hidden');
+      }
+    }
+  });
+}
+
 function initFMC() {
   const list = document.getElementById('events-list');
   if (list && !list.dataset.loaded) {
@@ -94,6 +113,7 @@ function initFMC() {
         const target = document.getElementById(targetId);
         if (target) {
           e.preventDefault();
+          showSection(targetId);
           const start = window.scrollY;
           const nav = document.querySelector('.sticky-nav');
           const navHeight = nav ? nav.offsetHeight : 0;
@@ -142,3 +162,4 @@ function typeText(el, text, speed) {
 
 document.addEventListener('DOMContentLoaded', initFMC);
 window.initFMC = initFMC;
+window.showSection = showSection;


### PR DESCRIPTION
## Summary
- Add `showSection` function to toggle visibility of page sections.
- Hook navigation links into `showSection` so selecting Home hides the Executive Board and other sections.
- Show only the Welcome and Background sections on initial load.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6892823664ac832dbab8d022fcdc04e0