### PR TITLE
Ensure home tab scrolls to top

### DIFF
--- a/docs/static/js/scripts.js
+++ b/docs/static/js/scripts.js
@@ -97,7 +97,10 @@ function initFMC() {
           const start = window.scrollY;
           const nav = document.querySelector('.sticky-nav');
           const navHeight = nav ? nav.offsetHeight : 0;
-          const end = target.getBoundingClientRect().top + start - navHeight;
+          // Always scroll to the very top when the "Home" tab is pressed
+          const end = targetId === 'home'
+            ? 0
+            : target.getBoundingClientRect().top + start - navHeight;
           const duration = 1800; // slowed scroll by 50%
           const startTime = performance.now();
 


### PR DESCRIPTION
## Summary
- Special-case Home nav anchor to always scroll to top of page.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689284cf4840832d8689a27eafdeb969