### PR TITLE
Align executive board text width with Background section

### DIFF
--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -37,10 +37,12 @@
 
   <main class="flex-grow py-8">
     <section class="max-w-6xl mx-auto px-4 glass">
+      <div class="max-w-3xl mx-auto">
       <h1 class="text-3xl font-bold text-center mb-6">Executive Board</h1>
       <p class="mb-8 text-left">
         The executive board manages the day-to-day operations and strategic direction of the club. We collaborate closely to design and deliver weekly workshops, events, and networking opportunities. Each member brings financial modeling experience gained through internships in the business world, ensuring they’ve applied modeling techniques in real professional settings. Feel free to contact any of our executive board members to learn more about their specific roles and experiences!
       </p>
+      </div>
         <div class="grid gap-6 sm:grid-cols-2 md:grid-cols-3">
           <div class="card">
             <img src="static/assets/images/DSawyer.jpeg" alt="Davis K. Sawyer" class="mx-auto h-40 w-40 object-cover">
@@ -125,7 +127,7 @@
 
     <section class="max-w-6xl mx-auto px-4 mt-12 glass">
       <h2 class="text-3xl font-bold text-center mb-6">Directors</h2>
-      <p class="mb-8 text-left">
+      <p class="mb-8 text-left max-w-3xl mx-auto">
         Directors support and carry out the goals set by the executive board. They work under the board to keep things running smoothly and help ensure every member has a great experience.
       </p>
         <div class="grid gap-8 sm:grid-cols-2 md:grid-cols-3">


### PR DESCRIPTION
## Summary
- Constrained the Executive Board description with a centered max-width container so its layout mirrors the Background section.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689be5a9f8ec8333baa239a3ba8be451