### PR TITLE
Center cards and prevent text overflow

### DIFF
--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -43,12 +43,12 @@
         The executive board manages the day-to-day operations and strategic direction of the club. We collaborate closely to design and deliver weekly workshops, events, and networking opportunities. Each member brings financial modeling experience gained through internships in the business world, ensuring they’ve applied modeling techniques in real professional settings. Feel free to contact any of our executive board members to learn more about their specific roles and experiences!
       </p>
       </div>
-        <div class="grid gap-6 sm:grid-cols-2 md:grid-cols-3">
+        <div class="grid gap-6 sm:grid-cols-2 md:grid-cols-3 place-items-center">
           <div class="card">
             <img src="static/assets/images/DSawyer.jpeg" alt="Davis K. Sawyer" class="mx-auto h-40 w-40 object-cover">
             <p class="mt-2 font-semibold text-center">Davis K. Sawyer</p>
-            <p class="text-sm text-center whitespace-nowrap">President &amp; Founder</p>
-              <p class="text-sm text-center mb-2 whitespace-nowrap">Finance '27</p>
+            <p class="text-sm text-center">President &amp; Founder</p>
+              <p class="text-sm text-center mb-2">Finance '27</p>
             <a href="https://www.linkedin.com/in/davis-sawyer-wm2027/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>
@@ -58,8 +58,8 @@
           <div class="card">
             <img src="static/assets/images/d0fc7244-6130-4de3-8353-b1ff33865f75.jpg" alt="Jack Aitken" class="mx-auto h-40 w-40 object-cover">
             <p class="mt-2 font-semibold text-center">Jack W. Aitken</p>
-            <p class="text-sm text-center whitespace-nowrap">VP, Financial Modeling</p>
-            <p class="text-sm text-center mb-2 whitespace-nowrap">Computer Science '27</p>
+            <p class="text-sm text-center">VP, Financial Modeling</p>
+            <p class="text-sm text-center mb-2">Computer Science '27</p>
             <a href="https://www.linkedin.com/in/jack-aitken-b516a5282/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>
@@ -69,9 +69,9 @@
           <div class="card">
             <img src="static/assets/images/IMG_9764 (1) - Edited - Edited.jpg" alt="Daniel R. Butler" class="mx-auto h-40 w-40 object-cover">
             <p class="mt-2 font-semibold text-center">Daniel R. Butler</p>
-              <p class="text-sm text-center whitespace-nowrap">VP, Operations</p>
-              <p class="text-sm text-center whitespace-nowrap">Applied Math '25</p>
-            <p class="text-sm text-center mb-2 whitespace-nowrap">MS Computer Science '27</p>
+              <p class="text-sm text-center">VP, Operations</p>
+              <p class="text-sm text-center">Applied Math '25</p>
+            <p class="text-sm text-center mb-2">MS Computer Science '27</p>
             <a href="https://www.linkedin.com/in/daniel-butler-a1ba3a296/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>
@@ -81,8 +81,8 @@
           <div class="card">
             <img src="static/assets/images/IMG_3556 - Edited.jpg" alt="Tom Chesnut" class="mx-auto h-40 w-40 object-cover">
             <p class="mt-2 font-semibold text-center">Tom G. Chesnut</p>
-              <p class="text-sm text-center whitespace-nowrap">VP, Mentorship</p>
-            <p class="text-sm text-center mb-2 whitespace-nowrap">History &amp; Religion '27</p>
+              <p class="text-sm text-center">VP, Mentorship</p>
+            <p class="text-sm text-center mb-2">History &amp; Religion '27</p>
             <a href="https://www.linkedin.com/in/tom-chesnut-2593a329b/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>
@@ -92,8 +92,8 @@
           <div class="card">
             <img src="static/assets/images/Luke Archey-modified - Edited.jpg" alt="Luke X. Archey" class="mx-auto h-40 w-40 object-cover">
             <p class="mt-2 font-semibold text-center">Luke X. Archey</p>
-              <p class="text-sm text-center whitespace-nowrap">VP, Marketing</p>
-              <p class="text-sm text-center mb-2 whitespace-nowrap">Economics '26</p>
+              <p class="text-sm text-center">VP, Marketing</p>
+              <p class="text-sm text-center mb-2">Economics '26</p>
             <a href="https://www.linkedin.com/in/luke-archey-a23668263/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>
@@ -103,8 +103,8 @@
           <div class="card">
             <img src="static/assets/images/IMG_9763 - Edited.jpg" alt="Ben L. Michaud" class="mx-auto h-40 w-40 object-cover">
             <p class="mt-2 font-semibold text-center">Ben L. Michaud</p>
-              <p class="text-sm text-center whitespace-nowrap">VP, Finance</p>
-              <p class="text-sm text-center mb-2 whitespace-nowrap">Economics '26</p>
+              <p class="text-sm text-center">VP, Finance</p>
+              <p class="text-sm text-center mb-2">Economics '26</p>
             <a href="https://www.linkedin.com/in/benmichaud1/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>
@@ -114,8 +114,8 @@
           <div class="card">
             <img src="static/assets/images/bd75a459-8924-464c-8823-f3a3dfd9c335.png" alt="Alex B. Aitken" class="mx-auto h-40 w-40 object-cover">
             <p class="mt-2 font-semibold text-center">Alex B. Aitken</p>
-            <p class="text-sm text-center whitespace-nowrap">VP, Corporate Relations</p>
-            <p class="text-sm text-center mb-2 whitespace-nowrap">Finance '26</p>
+            <p class="text-sm text-center">VP, Corporate Relations</p>
+            <p class="text-sm text-center mb-2">Finance '26</p>
             <a href="https://www.linkedin.com/in/alex-aitken-1b8b80271/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>
@@ -130,12 +130,12 @@
       <p class="mb-8 text-left max-w-3xl mx-auto">
         Directors support and carry out the goals set by the executive board. They work under the board to keep things running smoothly and help ensure every member has a great experience.
       </p>
-        <div class="grid gap-8 sm:grid-cols-2 md:grid-cols-3">
+        <div class="grid gap-8 sm:grid-cols-2 md:grid-cols-3 place-items-center">
           <div class="card">
             <img src="static/assets/images/297db81b-4a12-4c0b-b739-5fcb7aa892cc.jpg" alt="Audrey P. Sims" class="mx-auto h-40 w-40 object-cover">
             <p class="mt-2 font-semibold text-center">Audrey P. Sims</p>
-              <p class="text-sm text-center whitespace-nowrap">Director, Marketing</p>
-              <p class="text-sm text-center mb-2 whitespace-nowrap">Finance '27</p>
+              <p class="text-sm text-center">Director, Marketing</p>
+              <p class="text-sm text-center mb-2">Finance '27</p>
             <a href="https://www.linkedin.com/in/audreysims" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>
@@ -144,9 +144,9 @@
           </div>
           <div class="card">
             <img src="static/assets/images/IMG_0039.JPG" alt="Tristan C. Jander" class="mx-auto h-40 w-40 object-cover">
-              <p class="mt-2 font-semibold text-center whitespace-nowrap">Tristan C. Jander</p>
-              <p class="text-sm text-center whitespace-nowrap">Director, Finance</p>
-              <p class="text-sm text-center mb-2 whitespace-nowrap">Accounting '27</p>
+              <p class="mt-2 font-semibold text-center">Tristan C. Jander</p>
+              <p class="text-sm text-center">Director, Finance</p>
+              <p class="text-sm text-center mb-2">Accounting '27</p>
             <a href="https://www.linkedin.com/in/tristan-jander/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>
@@ -156,8 +156,8 @@
           <div class="card">
             <img src="static/assets/images/AKochell.JPG" alt="Alex R. Kochell" class="mx-auto h-40 w-40 object-cover">
             <p class="mt-2 font-semibold text-center">Alex R. Kochell</p>
-              <p class="text-sm text-center whitespace-nowrap">Director, Operations</p>
-              <p class="text-sm text-center mb-2 whitespace-nowrap">Finance '27</p>
+              <p class="text-sm text-center">Director, Operations</p>
+              <p class="text-sm text-center mb-2">Finance '27</p>
             <a href="https://www.linkedin.com/in/alex-kochell-8925492b9/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>
@@ -166,9 +166,9 @@
           </div>
           <div class="card">
             <img src="static/assets/images/eb09a524-9146-4e54-8275-166d4b9ee4d9 (1).jpg" alt="Benjamin M. Monforth" class="mx-auto h-40 w-40 object-cover">
-            <p class="mt-2 font-semibold text-center whitespace-nowrap">Benjamin M. Monforth</p>
-            <p class="text-sm text-center whitespace-nowrap">Director, Corporate Relations</p>
-            <p class="text-sm text-center mb-2 whitespace-nowrap">Physics '26</p>
+            <p class="mt-2 font-semibold text-center">Benjamin M. Monforth</p>
+            <p class="text-sm text-center">Director, Corporate Relations</p>
+            <p class="text-sm text-center mb-2">Physics '26</p>
             <a href="https://www.linkedin.com/in/benjamin-monforth2026/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
                 <i class="fab fa-linkedin fa-2x linkedin-color"></i>

--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -37,13 +37,13 @@
 
   <main class="flex-grow py-8 glass m-4">
     <section class="max-w-3xl mx-auto px-4 text-center">
-      <h1 class="text-3xl font-bold mb-4 text-center whitespace-nowrap">Our Next Speaker</h1>
+      <h1 class="text-3xl font-bold mb-4 text-center">Our Next Speaker</h1>
       <div class="card">
         <div class="card-inner">
           <div class="card-front flex flex-col items-center">
             <img src="static/assets/images/61e078a2-a487-4882-99f0-f35db1ee22c3.jpg" alt="Thomas C. Sawyer" class="mx-auto h-40 w-40 object-cover mb-4 block">
-            <p class="mt-2 font-semibold text-center whitespace-nowrap">Thomas C. Sawyer</p>
-            <p class="mt-2 text-sm whitespace-nowrap text-center">Investment Banking Associate at Piper Sandler</p>
+            <p class="mt-2 font-semibold text-center">Thomas C. Sawyer</p>
+            <p class="mt-2 text-sm text-center">Investment Banking Associate at Piper Sandler</p>
           </div>
         </div>
       </div>

--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -88,6 +88,10 @@ main h6 {
 .card {
   width: 256px;
   margin: 1rem auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
   text-align: center;
   background: rgba(255, 255, 255, 0.1);
   border-radius: 1rem;
@@ -96,6 +100,7 @@ main h6 {
   -webkit-backdrop-filter: blur(10px);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   padding: 1rem;
+  overflow-wrap: anywhere;
 }
 
 /* Instagram marquee */


### PR DESCRIPTION
## Summary
- Center card contents using flexbox and allow text wrapping to keep content inside cards
- Remove `whitespace-nowrap` from card text and headings to prevent overflow
- Center grid layouts for team sections with `place-items-center`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689be92c3b788333b7f7dbbbdafe9128