### PR TITLE
Soften card styling with frosted transparency

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -89,11 +89,11 @@ main h6 {
   width: 256px;
   margin: 1rem auto;
   text-align: center;
-  background: rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
   border-radius: 1rem;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  backdrop-filter: blur(15px);
+  -webkit-backdrop-filter: blur(15px);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   padding: 1rem;
 }


### PR DESCRIPTION
## Summary
- Reduce card background opacity and enhance border for frosted glass effect
- Increase backdrop blur to reinforce glassy transparency

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689be8490ae08333aeb745fff57cf4c3