### PR TITLE
Remove shimmering effect from logo and Instagram icons

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -147,40 +147,12 @@ main h6 {
   opacity: 1;
 }
 
-/* Shimmer effect for logo */
+/* Container for the club logo */
 .logo-shimmer {
   position: relative;
   display: inline-block;
   overflow: hidden;
   border-radius: 50%;
-}
-
-.logo-shimmer::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: -100%;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(
-    120deg,
-    rgba(255, 255, 255, 0) 0%,
-    rgba(255, 255, 255, 0.6) 50%,
-    rgba(255, 255, 255, 0) 100%
-  );
-  transform: skewX(-25deg);
-  animation: logo-shimmer 2s infinite;
-  pointer-events: none;
-  border-radius: 50%;
-}
-
-@keyframes logo-shimmer {
-  0% {
-    left: -100%;
-  }
-  100% {
-    left: 100%;
-  }
 }
 
 /* 3D hover floating jiggle */
@@ -246,13 +218,13 @@ main h6 {
   color: #FFFFFF;
 }
 
-/* Jiggle and shine animations for social icons */
+/* Jiggle animation for social icons */
 .insta-icon:hover,
 .linkedin-icon:hover {
   animation: icon-jiggle 0.6s infinite;
 }
 
-.insta-icon::after,
+/* Shine effect for LinkedIn icon */
 .linkedin-icon::after {
   content: '';
   position: absolute;
@@ -270,7 +242,6 @@ main h6 {
   pointer-events: none;
 }
 
-.insta-icon:hover::after,
 .linkedin-icon:hover::after {
   animation: icon-shine 0.75s forwards;
 }


### PR DESCRIPTION
## Summary
- drop pseudo-element animation from `.logo-shimmer` to remove logo shine
- eliminate Instagram icon shine and scope shine animation to LinkedIn only

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689bed2ec2c483339cb4cd8a33ec3f4f