### PR TITLE
Use image files for social icons

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -51,7 +51,7 @@
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 underline hover:no-underline">financialmodel@wm.edu</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
         <span class="insta-icon logo-shimmer hover-jiggle">
-          <i class="fa-brands fa-instagram text-3xl insta-color"></i>
+          <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />
         </span>
       </a>
     </div>

--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -50,7 +50,7 @@
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 underline hover:no-underline">financialmodel@wm.edu</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
         <span class="insta-icon logo-shimmer hover-jiggle">
-          <i class="fa-brands fa-instagram text-3xl insta-color"></i>
+          <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />
         </span>
       </a>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -60,7 +60,7 @@
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 underline hover:no-underline">financialmodel@wm.edu</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
         <span class="insta-icon logo-shimmer hover-jiggle">
-          <i class="fa-brands fa-instagram text-3xl insta-color"></i>
+          <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />
         </span>
       </a>
     </div>

--- a/docs/instagram.html
+++ b/docs/instagram.html
@@ -41,7 +41,7 @@
         <p class="mt-3 text-center">
           <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram" class="inline-block">
             <span class="insta-icon logo-shimmer hover-jiggle">
-              <i class="fa-brands fa-instagram text-5xl insta-color"></i>
+              <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />
             </span>
           </a>
         </p>
@@ -54,7 +54,7 @@
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 underline hover:no-underline">financialmodel@wm.edu</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
         <span class="insta-icon logo-shimmer hover-jiggle">
-          <i class="fa-brands fa-instagram text-3xl insta-color"></i>
+          <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />
         </span>
       </a>
     </div>

--- a/docs/join.html
+++ b/docs/join.html
@@ -50,7 +50,7 @@
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 underline hover:no-underline">financialmodel@wm.edu</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
         <span class="insta-icon logo-shimmer hover-jiggle">
-          <i class="fa-brands fa-instagram text-3xl insta-color"></i>
+          <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />
         </span>
       </a>
     </div>

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -51,7 +51,7 @@
               <p class="text-sm text-center mb-2">Finance '27</p>
             <a href="https://www.linkedin.com/in/davis-sawyer-wm2027/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
-                <i class="fab fa-linkedin fa-2x linkedin-color"></i>
+                <img src="static/assets/images/LinkedIn_logo_initials.png" alt="LinkedIn logo" />
               </span>
             </a>
           </div>
@@ -62,7 +62,7 @@
             <p class="text-sm text-center mb-2">Computer Science '27</p>
             <a href="https://www.linkedin.com/in/jack-aitken-b516a5282/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
-                <i class="fab fa-linkedin fa-2x linkedin-color"></i>
+                <img src="static/assets/images/LinkedIn_logo_initials.png" alt="LinkedIn logo" />
               </span>
             </a>
           </div>
@@ -74,7 +74,7 @@
             <p class="text-sm text-center mb-2">MS Computer Science '27</p>
             <a href="https://www.linkedin.com/in/daniel-butler-a1ba3a296/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
-                <i class="fab fa-linkedin fa-2x linkedin-color"></i>
+                <img src="static/assets/images/LinkedIn_logo_initials.png" alt="LinkedIn logo" />
               </span>
             </a>
           </div>
@@ -85,7 +85,7 @@
             <p class="text-sm text-center mb-2">History &amp; Religion '27</p>
             <a href="https://www.linkedin.com/in/tom-chesnut-2593a329b/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
-                <i class="fab fa-linkedin fa-2x linkedin-color"></i>
+                <img src="static/assets/images/LinkedIn_logo_initials.png" alt="LinkedIn logo" />
               </span>
             </a>
           </div>
@@ -96,7 +96,7 @@
               <p class="text-sm text-center mb-2">Economics '26</p>
             <a href="https://www.linkedin.com/in/luke-archey-a23668263/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
-                <i class="fab fa-linkedin fa-2x linkedin-color"></i>
+                <img src="static/assets/images/LinkedIn_logo_initials.png" alt="LinkedIn logo" />
               </span>
             </a>
           </div>
@@ -107,7 +107,7 @@
               <p class="text-sm text-center mb-2">Economics '26</p>
             <a href="https://www.linkedin.com/in/benmichaud1/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
-                <i class="fab fa-linkedin fa-2x linkedin-color"></i>
+                <img src="static/assets/images/LinkedIn_logo_initials.png" alt="LinkedIn logo" />
               </span>
             </a>
           </div>
@@ -118,7 +118,7 @@
             <p class="text-sm text-center mb-2">Finance '26</p>
             <a href="https://www.linkedin.com/in/alex-aitken-1b8b80271/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
-                <i class="fab fa-linkedin fa-2x linkedin-color"></i>
+                <img src="static/assets/images/LinkedIn_logo_initials.png" alt="LinkedIn logo" />
               </span>
             </a>
           </div>
@@ -138,7 +138,7 @@
               <p class="text-sm text-center mb-2">Finance '27</p>
             <a href="https://www.linkedin.com/in/audreysims" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
-                <i class="fab fa-linkedin fa-2x linkedin-color"></i>
+                <img src="static/assets/images/LinkedIn_logo_initials.png" alt="LinkedIn logo" />
               </span>
             </a>
           </div>
@@ -149,7 +149,7 @@
               <p class="text-sm text-center mb-2">Accounting '27</p>
             <a href="https://www.linkedin.com/in/tristan-jander/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
-                <i class="fab fa-linkedin fa-2x linkedin-color"></i>
+                <img src="static/assets/images/LinkedIn_logo_initials.png" alt="LinkedIn logo" />
               </span>
             </a>
           </div>
@@ -160,7 +160,7 @@
               <p class="text-sm text-center mb-2">Finance '27</p>
             <a href="https://www.linkedin.com/in/alex-kochell-8925492b9/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
-                <i class="fab fa-linkedin fa-2x linkedin-color"></i>
+                <img src="static/assets/images/LinkedIn_logo_initials.png" alt="LinkedIn logo" />
               </span>
             </a>
           </div>
@@ -171,7 +171,7 @@
             <p class="text-sm text-center mb-2">Physics '26</p>
             <a href="https://www.linkedin.com/in/benjamin-monforth2026/" target="_blank" class="block text-center mt-2">
               <span class="linkedin-icon">
-                <i class="fab fa-linkedin fa-2x linkedin-color"></i>
+                <img src="static/assets/images/LinkedIn_logo_initials.png" alt="LinkedIn logo" />
               </span>
             </a>
           </div>
@@ -184,7 +184,7 @@
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 underline hover:no-underline">financialmodel@wm.edu</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
         <span class="insta-icon logo-shimmer hover-jiggle">
-          <i class="fa-brands fa-instagram text-3xl insta-color"></i>
+          <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />
         </span>
       </a>
     </div>

--- a/docs/schedule.html
+++ b/docs/schedule.html
@@ -48,7 +48,7 @@
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 underline hover:no-underline">financialmodel@wm.edu</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
         <span class="insta-icon logo-shimmer hover-jiggle">
-          <i class="fa-brands fa-instagram text-3xl insta-color"></i>
+          <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />
         </span>
       </a>
     </div>

--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -55,7 +55,7 @@
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 underline hover:no-underline">financialmodel@wm.edu</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
         <span class="insta-icon logo-shimmer hover-jiggle">
-          <i class="fa-brands fa-instagram text-3xl insta-color"></i>
+          <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />
         </span>
       </a>
     </div>

--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -224,10 +224,6 @@ main h6 {
   box-sizing: border-box;
 }
 
-.insta-color {
-  color: #FFFFFF;
-}
-
 .linkedin-icon {
   width: 3rem;
   height: 3rem;
@@ -242,8 +238,11 @@ main h6 {
   box-sizing: border-box;
 }
 
-.linkedin-color {
-  color: #FFFFFF;
+.insta-icon img,
+.linkedin-icon img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 /* Jiggle and shine animations for social icons */


### PR DESCRIPTION
## Summary
- display Instagram logo via `Instagram_logo_2022.svg.webp`
- show LinkedIn logos with `LinkedIn_logo_initials.png`
- size image-based icons within existing hover animation wrappers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689beebba3a0832d95eba716743ab0bb