### PR TITLE
Uniform leadership card height

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -87,6 +87,7 @@ main h6 {
 /* Team card layout */
 .card {
   width: 256px;
+  height: 21rem;
   margin: 1rem auto;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- Fix team card styling to enforce consistent height for all leadership entries

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689befdfba5883338c74d540f3f49f64