### PR TITLE
Apply glassmorphic styling to navigation menu

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -34,10 +34,17 @@ nav, nav * {
 /* Bubble border style for grouped nav tabs */
 .nav-tabs {
   display: inline-flex;
-  border: 1px solid rgba(128, 0, 128, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 9999px;
   padding: 0.25rem 0.75rem;
-  background-color: transparent;
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  transition: background 0.3s ease;
+}
+
+.nav-tabs:hover {
+  background: rgba(255, 255, 255, 0.2);
 }
 
 body * {


### PR DESCRIPTION
## Summary
- Style navigation menu with glassmorphic background, blur, and hover to match the sign-up button.

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689bf07c290483338af922826e42ac7d