### PR TITLE
Align executive board layout and standardize card sizes

### DIFF
--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -89,6 +89,7 @@
               </span>
             </a>
           </div>
+          <div class="basis-full h-0"></div>
           <div class="card">
             <img src="static/assets/images/Luke Archey-modified - Edited.jpg" alt="Luke X. Archey" class="mx-auto h-40 w-40 object-cover">
             <p class="mt-2 font-semibold text-center">Luke X. Archey</p>

--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -104,6 +104,12 @@ main h6 {
   overflow-wrap: anywhere;
 }
 
+.card img {
+  width: 10rem;
+  height: 10rem;
+  object-fit: cover;
+}
+
 /* Instagram marquee */
 .insta-marquee {
   overflow: hidden;


### PR DESCRIPTION
## Summary
- Force executive board cards to wrap into 4 cards on the first row and 3 on the second
- Standardize card image dimensions so every team member displays uniformly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689bf0ef080c8333be5172f950cc764b