### PR TITLE
Remove circular styling from social icons

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -186,29 +186,29 @@ main h6 {
 .insta-icon {
   width: 3rem;
   height: 3rem;
-  border-radius: 50%;
-  padding: 0.5rem;
+  padding: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background-color: #E1306C;
   position: relative;
   overflow: hidden;
   box-sizing: border-box;
+  border-radius: 0;
+  background: none;
 }
 
 .linkedin-icon {
   width: 3rem;
   height: 3rem;
-  border-radius: 50%;
-  padding: 0.5rem;
+  padding: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background-color: #0A66C2;
   position: relative;
   overflow: hidden;
   box-sizing: border-box;
+  border-radius: 0;
+  background: none;
 }
 
 .insta-icon img,


### PR DESCRIPTION
## Summary
- eliminate circular backgrounds on Instagram and LinkedIn logos

## Testing
- `npm test` (fails: ENOENT: no such file or directory, open '/workspace/FMC-W-M/package.json')

------
https://chatgpt.com/codex/tasks/task_b_689bf1998348833396b43c6fad3f85dc