### PR TITLE
chore: widen team cards

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -94,7 +94,7 @@ main h6 {
 
 /* Team card layout */
 .card {
-  width: 256px;
+  width: 288px;
   height: 21rem;
   margin: 1rem auto;
   display: flex;


### PR DESCRIPTION
## Summary
- make people cards a bit wider to fit long academic text on one line

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689bf2aae4648333aedbaf3f4904c1a4