### PR TITLE
Reduce logo text size

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -23,7 +23,7 @@ nav, nav * {
 
 /* Nav title with larger, bold text */
 .nav-title {
-  font-size: 1.125rem;
+  font-size: 1rem;
   font-weight: 700;
 }
 


### PR DESCRIPTION
## Summary
- decrease nav title font size to make logo text smaller

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689bf2e1eb348333bd3aac356299623a