### PR TITLE
Reduce social icon size

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -198,8 +198,8 @@ main h6 {
 
 /* Instagram follow icon styles */
 .insta-icon {
-  width: 3rem;
-  height: 3rem;
+  width: 2.5rem;
+  height: 2.5rem;
   padding: 0;
   display: inline-flex;
   align-items: center;
@@ -212,8 +212,8 @@ main h6 {
 }
 
 .linkedin-icon {
-  width: 3rem;
-  height: 3rem;
+  width: 2.5rem;
+  height: 2.5rem;
   padding: 0;
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- shrink LinkedIn and Instagram icons for a subtler footer and profile links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689bf52bf4ac833385dedb33e28b865c