### PR TITLE
Remove underline from email links

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -48,7 +48,7 @@
 
   <footer class="glass py-4 text-center">
     <div class="flex justify-center items-center space-x-4">
-      <a href="mailto:financialmodel@wm.edu" class="text-blue-500 underline hover:no-underline">financialmodel@wm.edu</a>
+      <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
         <span class="insta-icon logo-shimmer hover-jiggle">
           <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />

--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -47,7 +47,7 @@
 
   <footer class="glass py-4 text-center">
     <div class="flex justify-center items-center space-x-4">
-      <a href="mailto:financialmodel@wm.edu" class="text-blue-500 underline hover:no-underline">financialmodel@wm.edu</a>
+      <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
         <span class="insta-icon logo-shimmer hover-jiggle">
           <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />

--- a/docs/index.html
+++ b/docs/index.html
@@ -57,7 +57,7 @@
 
   <footer class="glass py-4 text-center">
     <div class="flex justify-center items-center space-x-4">
-      <a href="mailto:financialmodel@wm.edu" class="text-blue-500 underline hover:no-underline">financialmodel@wm.edu</a>
+      <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
         <span class="insta-icon logo-shimmer hover-jiggle">
           <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />

--- a/docs/instagram.html
+++ b/docs/instagram.html
@@ -51,7 +51,7 @@
 
   <footer class="glass py-4 text-center">
     <div class="flex justify-center items-center space-x-4">
-      <a href="mailto:financialmodel@wm.edu" class="text-blue-500 underline hover:no-underline">financialmodel@wm.edu</a>
+      <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
         <span class="insta-icon logo-shimmer hover-jiggle">
           <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />

--- a/docs/join.html
+++ b/docs/join.html
@@ -47,7 +47,7 @@
 
   <footer class="glass py-4 text-center">
     <div class="flex justify-center items-center space-x-4">
-      <a href="mailto:financialmodel@wm.edu" class="text-blue-500 underline hover:no-underline">financialmodel@wm.edu</a>
+      <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
         <span class="insta-icon logo-shimmer hover-jiggle">
           <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -182,7 +182,7 @@
 
   <footer class="glass py-4 text-center">
     <div class="flex justify-center items-center space-x-4">
-      <a href="mailto:financialmodel@wm.edu" class="text-blue-500 underline hover:no-underline">financialmodel@wm.edu</a>
+      <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
         <span class="insta-icon logo-shimmer hover-jiggle">
           <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />

--- a/docs/schedule.html
+++ b/docs/schedule.html
@@ -45,7 +45,7 @@
 
   <footer class="glass py-4 text-center">
     <div class="flex justify-center items-center space-x-4">
-      <a href="mailto:financialmodel@wm.edu" class="text-blue-500 underline hover:no-underline">financialmodel@wm.edu</a>
+      <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
         <span class="insta-icon logo-shimmer hover-jiggle">
           <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />

--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -52,7 +52,7 @@
 
   <footer class="glass py-4 text-center">
     <div class="flex justify-center items-center space-x-4">
-      <a href="mailto:financialmodel@wm.edu" class="text-blue-500 underline hover:no-underline">financialmodel@wm.edu</a>
+      <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
         <span class="insta-icon logo-shimmer hover-jiggle">
           <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />


### PR DESCRIPTION
## Summary
- Remove default underline from contact email links across all pages using Tailwind's `no-underline` class.

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689bf555e66c833384a56be9ded13dc3