### PR TITLE
Add dynamic copyright footer

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -55,6 +55,7 @@
         </span>
       </a>
     </div>
+    <p class="mt-2 text-sm text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</p>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -54,6 +54,7 @@
         </span>
       </a>
     </div>
+    <p class="mt-2 text-sm text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</p>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -64,6 +64,7 @@
         </span>
       </a>
     </div>
+    <p class="mt-2 text-sm text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</p>
   </footer>
 
   <script type="module" src="static/js/waveBackground.js"></script>

--- a/docs/instagram.html
+++ b/docs/instagram.html
@@ -58,6 +58,7 @@
         </span>
       </a>
     </div>
+    <p class="mt-2 text-sm text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</p>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/join.html
+++ b/docs/join.html
@@ -54,6 +54,7 @@
         </span>
       </a>
     </div>
+    <p class="mt-2 text-sm text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</p>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -189,6 +189,7 @@
         </span>
       </a>
     </div>
+    <p class="mt-2 text-sm text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</p>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/schedule.html
+++ b/docs/schedule.html
@@ -52,6 +52,7 @@
         </span>
       </a>
     </div>
+    <p class="mt-2 text-sm text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</p>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -59,6 +59,7 @@
         </span>
       </a>
     </div>
+    <p class="mt-2 text-sm text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</p>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/static/js/scripts.js
+++ b/docs/static/js/scripts.js
@@ -1,4 +1,7 @@
 function initFMC() {
+  document.querySelectorAll('.copyright-year').forEach(span => {
+    span.textContent = new Date().getFullYear();
+  });
   const list = document.getElementById('events-list');
   if (list && !list.dataset.loaded) {
     fetch('data/events.json')


### PR DESCRIPTION
## Summary
- Add dynamic copyright footer across all pages with current year
- Populate year dynamically via JavaScript

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_b_689bf65718008333b1edd3e79d0b678c