### PR TITLE
Add privacy policy page and footer link

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -49,6 +49,7 @@
   <footer class="glass py-4 text-center">
     <div class="flex justify-center items-center space-x-4">
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
+      <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
         <span class="insta-icon logo-shimmer hover-jiggle">
           <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />

--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -48,6 +48,7 @@
   <footer class="glass py-4 text-center">
     <div class="flex justify-center items-center space-x-4">
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
+      <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
         <span class="insta-icon logo-shimmer hover-jiggle">
           <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />

--- a/docs/index.html
+++ b/docs/index.html
@@ -58,6 +58,7 @@
   <footer class="glass py-4 text-center">
     <div class="flex justify-center items-center space-x-4">
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
+      <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
         <span class="insta-icon logo-shimmer hover-jiggle">
           <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />

--- a/docs/instagram.html
+++ b/docs/instagram.html
@@ -52,6 +52,7 @@
   <footer class="glass py-4 text-center">
     <div class="flex justify-center items-center space-x-4">
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
+      <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
         <span class="insta-icon logo-shimmer hover-jiggle">
           <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />

--- a/docs/join.html
+++ b/docs/join.html
@@ -48,6 +48,7 @@
   <footer class="glass py-4 text-center">
     <div class="flex justify-center items-center space-x-4">
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
+      <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
         <span class="insta-icon logo-shimmer hover-jiggle">
           <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -183,6 +183,7 @@
   <footer class="glass py-4 text-center">
     <div class="flex justify-center items-center space-x-4">
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
+      <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
         <span class="insta-icon logo-shimmer hover-jiggle">
           <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy – Financial Modeling Club at William & Mary</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css" rel="stylesheet">
+  <link href="static/css/glass.css" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="flex flex-col min-h-screen bg-gradient-to-br from-gray-200 to-gray-50">
+  <nav class="glass shadow rounded-none sticky-nav">
+    <div class="max-w-7xl mx-auto px-4">
+      <div class="relative flex items-center justify-center py-4 h-24">
+        <a href="index.html" class="absolute left-4 top-1/2 -translate-y-1/2 flex items-center">
+          <div class="logo-shimmer hover-jiggle">
+            <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
+          </div>
+          <div class="ml-2 hover-jiggle">
+            <span class="block nav-title">Financial Modeling Club</span>
+            <span class="block nav-title">@ William & Mary</span>
+          </div>
+        </a>
+        <ul class="nav-tabs space-x-4">
+          <li><a href="index.html" class="hover-jiggle no-underline"><span>Home</span></a></li>
+          <li><a href="leadership.html" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
+          <li><a href="howwework.html" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
+          <li><a href="https://calendar.google.com/calendar/embed?src=aa3e8ef9cbda489545ecfcc3ae5daee0e2b0aaf5cfbd6211699381c04be035c8%40group.calendar.google.com&amp;ctz=America%2FNew_York" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
+        </ul>
+        <div class="absolute right-4 top-1/2 -translate-y-1/2">
+          <a href="https://forms.gle/g9i47Hh5tsbSpKV19" class="hover-jiggle no-underline glass-button"><span>Sign Up</span></a>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main class="flex-grow">
+    <section class="py-8 glass mx-4 mb-4 mt-0">
+      <div class="max-w-3xl px-4 mx-auto">
+        <h1 class="text-3xl font-bold mb-4 text-center">Privacy Policy</h1>
+
+        <h2 class="text-xl font-semibold mt-4">1. Introduction</h2>
+        <p>The William &amp; Mary Financial Modeling Club (“we,” “our,” or “the Club”) is committed to protecting the privacy and confidentiality of our members, event participants, and visitors to our platforms. This Privacy Policy explains how we collect, use, store, and protect personal information.</p>
+        <p>By joining the Club, attending events, or interacting with our online resources, you consent to the practices described in this Privacy Policy.</p>
+
+        <h2 class="text-xl font-semibold mt-4">2. Information We Collect</h2>
+        <p>We may collect the following types of information:</p>
+        <h3 class="font-semibold mt-2">a. Personal Information You Provide</h3>
+        <ul class="list-disc ml-6">
+          <li>Name, email address, and phone number (for membership or event registration)</li>
+          <li>Academic information (e.g., major, graduation year, academic interests)</li>
+          <li>Payment information (if applicable for event fees, merchandise, or trips)</li>
+          <li>Any information voluntarily shared in surveys, feedback forms, or applications</li>
+        </ul>
+        <h3 class="font-semibold mt-2">b. Automatically Collected Information</h3>
+        <ul class="list-disc ml-6">
+          <li>Device type, browser type, and operating system</li>
+          <li>IP address and approximate location data</li>
+          <li>Usage data (pages visited, time spent on site)</li>
+        </ul>
+        <h3 class="font-semibold mt-2">c. Information from Third Parties</h3>
+        <p>We may receive member data from William &amp; Mary’s student organization management system or affiliated campus departments.</p>
+
+        <h2 class="text-xl font-semibold mt-4">3. How We Use Your Information</h2>
+        <p>We use collected information to:</p>
+        <ul class="list-disc ml-6">
+          <li>Manage club membership and communications</li>
+          <li>Organize and promote events, workshops, and competitions</li>
+          <li>Provide educational resources and training materials</li>
+          <li>Process payments for club-related activities</li>
+          <li>Maintain records required by William &amp; Mary or applicable regulations</li>
+          <li>Improve our programs and website functionality</li>
+        </ul>
+
+        <h2 class="text-xl font-semibold mt-4">4. How We Share Your Information</h2>
+        <p>We do not sell personal information to third parties. We may share data only in the following cases:</p>
+        <ul class="list-disc ml-6">
+          <li>With Club Officers and Advisors for administrative purposes</li>
+          <li>With Event Partners (e.g., competition organizers, guest speakers) when necessary for participation</li>
+          <li>With William &amp; Mary Administration when required for compliance or reporting</li>
+          <li>With Legal Authorities when required by law</li>
+        </ul>
+
+        <h2 class="text-xl font-semibold mt-4">5. Data Storage and Security</h2>
+        <p>We take reasonable measures to protect your personal data from unauthorized access, alteration, disclosure, or destruction. Data may be stored on:</p>
+        <ul class="list-disc ml-6">
+          <li>Secure cloud-based platforms (e.g., Google Workspace for Education)</li>
+          <li>William &amp; Mary’s official student organization systems</li>
+        </ul>
+        <p>Only authorized club officers and advisors will have access to member data.</p>
+
+        <h2 class="text-xl font-semibold mt-4">6. Data Retention</h2>
+        <p>We retain personal data only as long as necessary for club operations or as required by William &amp; Mary policy. At the end of each academic year, outdated or unnecessary data will be deleted or anonymized.</p>
+
+        <h2 class="text-xl font-semibold mt-4">7. Your Rights</h2>
+        <p>You may:</p>
+        <ul class="list-disc ml-6">
+          <li>Request a copy of your personal data we hold</li>
+          <li>Request correction of inaccurate information</li>
+          <li>Request deletion of your data (subject to any legal or reporting obligations)</li>
+          <li>Opt out of club email communications at any time</li>
+        </ul>
+        <p>Requests can be made by contacting us at <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>.</p>
+
+        <h2 class="text-xl font-semibold mt-4">8. Use of Cookies &amp; Tracking Technologies</h2>
+        <p>If we operate a website, cookies may be used to improve user experience and analyze website traffic. You may disable cookies through your browser settings, but some site features may not function properly.</p>
+
+        <h2 class="text-xl font-semibold mt-4">9. Third-Party Links</h2>
+        <p>Our website, emails, or event materials may contain links to third-party websites. We are not responsible for the privacy practices of these external sites.</p>
+
+        <h2 class="text-xl font-semibold mt-4">10. Policy Updates</h2>
+        <p>We may update this Privacy Policy from time to time. Any significant changes will be communicated via club email and posted on our website.</p>
+      </div>
+    </section>
+  </main>
+
+  <footer class="glass py-4 text-center">
+    <div class="flex justify-center items-center space-x-4">
+      <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
+      <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
+      <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
+        <span class="insta-icon logo-shimmer hover-jiggle">
+          <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />
+        </span>
+      </a>
+    </div>
+    <p class="mt-2 text-sm text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</p>
+  </footer>
+
+  <script src="static/js/scripts.js"></script>
+</body>
+</html>

--- a/docs/schedule.html
+++ b/docs/schedule.html
@@ -46,6 +46,7 @@
   <footer class="glass py-4 text-center">
     <div class="flex justify-center items-center space-x-4">
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
+      <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
         <span class="insta-icon logo-shimmer hover-jiggle">
           <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />

--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -53,6 +53,7 @@
   <footer class="glass py-4 text-center">
     <div class="flex justify-center items-center space-x-4">
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
+      <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
         <span class="insta-icon logo-shimmer hover-jiggle">
           <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />


### PR DESCRIPTION
## Summary
- Add standalone Privacy Policy page outlining data collection, usage, sharing, and member rights.
- Link the new policy in the footer across all site pages for easy access.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689bf92f22548333a334a8a0c6fe47be