### PR TITLE
Align footer content on one line

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -47,7 +47,8 @@
   </main>
 
   <footer class="glass py-4 text-center">
-    <div class="flex justify-center items-center space-x-4">
+    <div class="flex justify-center items-center space-x-4 text-sm">
+      <span class="text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</span>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
       <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
@@ -56,7 +57,6 @@
         </span>
       </a>
     </div>
-    <p class="mt-2 text-sm text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</p>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -46,7 +46,8 @@
   </main>
 
   <footer class="glass py-4 text-center">
-    <div class="flex justify-center items-center space-x-4">
+    <div class="flex justify-center items-center space-x-4 text-sm">
+      <span class="text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</span>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
       <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
@@ -55,7 +56,6 @@
         </span>
       </a>
     </div>
-    <p class="mt-2 text-sm text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</p>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -56,7 +56,8 @@
   </main>
 
   <footer class="glass py-4 text-center">
-    <div class="flex justify-center items-center space-x-4">
+    <div class="flex justify-center items-center space-x-4 text-sm">
+      <span class="text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</span>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
       <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
@@ -65,7 +66,6 @@
         </span>
       </a>
     </div>
-    <p class="mt-2 text-sm text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</p>
   </footer>
 
   <script type="module" src="static/js/waveBackground.js"></script>

--- a/docs/instagram.html
+++ b/docs/instagram.html
@@ -50,7 +50,8 @@
   </main>
 
   <footer class="glass py-4 text-center">
-    <div class="flex justify-center items-center space-x-4">
+    <div class="flex justify-center items-center space-x-4 text-sm">
+      <span class="text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</span>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
       <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
@@ -59,7 +60,6 @@
         </span>
       </a>
     </div>
-    <p class="mt-2 text-sm text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</p>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/join.html
+++ b/docs/join.html
@@ -46,7 +46,8 @@
   </main>
 
   <footer class="glass py-4 text-center">
-    <div class="flex justify-center items-center space-x-4">
+    <div class="flex justify-center items-center space-x-4 text-sm">
+      <span class="text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</span>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
       <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
@@ -55,7 +56,6 @@
         </span>
       </a>
     </div>
-    <p class="mt-2 text-sm text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</p>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -181,7 +181,8 @@
   </main>
 
   <footer class="glass py-4 text-center">
-    <div class="flex justify-center items-center space-x-4">
+    <div class="flex justify-center items-center space-x-4 text-sm">
+      <span class="text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</span>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
       <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
@@ -190,7 +191,6 @@
         </span>
       </a>
     </div>
-    <p class="mt-2 text-sm text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</p>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -116,7 +116,8 @@
   </main>
 
   <footer class="glass py-4 text-center">
-    <div class="flex justify-center items-center space-x-4">
+    <div class="flex justify-center items-center space-x-4 text-sm">
+      <span class="text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</span>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
       <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
@@ -125,7 +126,6 @@
         </span>
       </a>
     </div>
-    <p class="mt-2 text-sm text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</p>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/schedule.html
+++ b/docs/schedule.html
@@ -44,7 +44,8 @@
   </main>
 
   <footer class="glass py-4 text-center">
-    <div class="flex justify-center items-center space-x-4">
+    <div class="flex justify-center items-center space-x-4 text-sm">
+      <span class="text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</span>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
       <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
@@ -53,7 +54,6 @@
         </span>
       </a>
     </div>
-    <p class="mt-2 text-sm text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</p>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -51,7 +51,8 @@
   </main>
 
   <footer class="glass py-4 text-center">
-    <div class="flex justify-center items-center space-x-4">
+    <div class="flex justify-center items-center space-x-4 text-sm">
+      <span class="text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</span>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
       <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
@@ -60,7 +61,6 @@
         </span>
       </a>
     </div>
-    <p class="mt-2 text-sm text-gray-600">&copy; <span class="copyright-year"></span> Financial Modeling Club at William & Mary</p>
   </footer>
 
   <script src="static/js/scripts.js"></script>


### PR DESCRIPTION
## Summary
- Display copyright, contact email, privacy policy, and Instagram link on a single line in page footers

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689bfb57fc708333a11ddfdeeef5eafe