### PR TITLE
Center paragraphs while keeping text left-aligned

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -57,6 +57,7 @@ p {
   max-width: 65ch;
   margin-left: auto;
   margin-right: auto;
+  text-align: left;
 }
 
 #intro-message {


### PR DESCRIPTION
## Summary
- keep paragraph blocks centered while forcing left-aligned text

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689bfba95dac833398d5633378eca490