### PR TITLE
Align paragraph and heading text to center

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -57,6 +57,16 @@ p {
   max-width: 65ch;
   margin-left: auto;
   margin-right: auto;
+}
+
+/* Center text for paragraphs and headings */
+main p,
+main h1,
+main h2,
+main h3,
+main h4,
+main h5,
+main h6 {
   text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- Ensure paragraphs have centered layout
- Center-align heading and paragraph text across the site for a consistent appearance

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689bfe66df5883339d9868e7dccd22ad