### PR TITLE
Revert glassmorphic navbar styling

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -84,14 +84,11 @@ main h6 {
   left: 0;
   width: 100%;
   z-index: 50;
+  background: rgba(255, 255, 255, 0.1);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
 }
-.sticky-nav.glass {
-  background: rgba(255, 255, 255, 0.1) !important;
-  border: 1px solid rgba(255, 255, 255, 0.2) !important;
-  backdrop-filter: blur(10px) !important;
-  -webkit-backdrop-filter: blur(10px) !important;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1) !important;
-  }
 
 /* Transparent glassmorphic utility */
 .glass {


### PR DESCRIPTION
## Summary
- revert merge that added glassmorphic navbar
- restore original sticky nav CSS and drop `.sticky-nav.glass` override

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689bff7ed48083339cf4783c73aa5ab6