### PR TITLE
Center privacy policy text

### DIFF
--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -38,8 +38,8 @@
 
   <main class="flex-grow">
     <section class="py-8 glass mx-4 mb-4 mt-0">
-      <div class="max-w-3xl px-4 mx-auto">
-        <h1 class="text-3xl font-bold mb-4 text-center">Privacy Policy</h1>
+      <div class="max-w-3xl px-4 mx-auto text-center">
+        <h1 class="text-3xl font-bold mb-4">Privacy Policy</h1>
 
         <h2 class="text-xl font-semibold mt-4">1. Introduction</h2>
         <p>The William &amp; Mary Financial Modeling Club (“we,” “our,” or “the Club”) is committed to protecting the privacy and confidentiality of our members, event participants, and visitors to our platforms. This Privacy Policy explains how we collect, use, store, and protect personal information.</p>
@@ -48,14 +48,14 @@
         <h2 class="text-xl font-semibold mt-4">2. Information We Collect</h2>
         <p>We may collect the following types of information:</p>
         <h3 class="font-semibold mt-2">a. Personal Information You Provide</h3>
-        <ul class="list-disc ml-6">
+        <ul class="list-disc ml-6 text-left">
           <li>Name, email address, and phone number (for membership or event registration)</li>
           <li>Academic information (e.g., major, graduation year, academic interests)</li>
           <li>Payment information (if applicable for event fees, merchandise, or trips)</li>
           <li>Any information voluntarily shared in surveys, feedback forms, or applications</li>
         </ul>
         <h3 class="font-semibold mt-2">b. Automatically Collected Information</h3>
-        <ul class="list-disc ml-6">
+        <ul class="list-disc ml-6 text-left">
           <li>Device type, browser type, and operating system</li>
           <li>IP address and approximate location data</li>
           <li>Usage data (pages visited, time spent on site)</li>
@@ -65,7 +65,7 @@
 
         <h2 class="text-xl font-semibold mt-4">3. How We Use Your Information</h2>
         <p>We use collected information to:</p>
-        <ul class="list-disc ml-6">
+        <ul class="list-disc ml-6 text-left">
           <li>Manage club membership and communications</li>
           <li>Organize and promote events, workshops, and competitions</li>
           <li>Provide educational resources and training materials</li>
@@ -76,7 +76,7 @@
 
         <h2 class="text-xl font-semibold mt-4">4. How We Share Your Information</h2>
         <p>We do not sell personal information to third parties. We may share data only in the following cases:</p>
-        <ul class="list-disc ml-6">
+        <ul class="list-disc ml-6 text-left">
           <li>With Club Officers and Advisors for administrative purposes</li>
           <li>With Event Partners (e.g., competition organizers, guest speakers) when necessary for participation</li>
           <li>With William &amp; Mary Administration when required for compliance or reporting</li>
@@ -85,7 +85,7 @@
 
         <h2 class="text-xl font-semibold mt-4">5. Data Storage and Security</h2>
         <p>We take reasonable measures to protect your personal data from unauthorized access, alteration, disclosure, or destruction. Data may be stored on:</p>
-        <ul class="list-disc ml-6">
+        <ul class="list-disc ml-6 text-left">
           <li>Secure cloud-based platforms (e.g., Google Workspace for Education)</li>
           <li>William &amp; Mary’s official student organization systems</li>
         </ul>
@@ -96,7 +96,7 @@
 
         <h2 class="text-xl font-semibold mt-4">7. Your Rights</h2>
         <p>You may:</p>
-        <ul class="list-disc ml-6">
+        <ul class="list-disc ml-6 text-left">
           <li>Request a copy of your personal data we hold</li>
           <li>Request correction of inaccurate information</li>
           <li>Request deletion of your data (subject to any legal or reporting obligations)</li>


### PR DESCRIPTION
## Summary
- center privacy policy body content so headings and paragraphs align to the middle
- keep bullet lists readable while surrounding text centers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689bfec760ec83339114257a2c3dcbfe