### PR TITLE
Center homepage text

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -48,8 +48,8 @@
     <section id="home" class="p-4 pt-0 glass">
       <section class="text-center py-3">
         <div class="max-w-4xl mx-auto">
-          <h1 class="text-2xl font-bold text-gray-700">Welcome to the Financial Modeling Club</h1>
-          <p id="intro-message" class="mt-2 fade-in-block">Combining advice from professionals in finance with student-led workshops to develop essential financial modeling skills</p>
+          <h1 class="text-2xl font-bold text-gray-700 text-center">Welcome to the Financial Modeling Club</h1>
+          <p id="intro-message" class="mt-2 fade-in-block text-center">Combining advice from professionals in finance with student-led workshops to develop essential financial modeling skills</p>
         </div>
       </section>
 

--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -75,6 +75,7 @@ main h6 {
   font-size: 1.875rem !important; /* Tailwind's text-3xl */
   line-height: 2.25rem !important;
   font-family: "Courier New", monospace;
+  text-align: center;
 }
 
 /* Sticky navigation bar */


### PR DESCRIPTION
## Summary
- center homepage heading and intro paragraph
- enforce centered alignment for headings site-wide

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689bfea921f48333ab814f5694dd0ee8