### PR TITLE
fix: center about page text

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -45,7 +45,7 @@
     <section class="py-8 glass mx-4 mb-4 mt-0">
       <div class="max-w-3xl px-4 mx-auto">
         <h1 class="text-3xl font-bold mb-4 text-center">Background</h1>
-        <p class="text-center">
+        <p class="mx-auto text-center max-w-prose">
           The Financial Modeling Club was founded in early 2025 to be a welcoming environment for undergraduate students to learn about modeling and to hone their skills. The club welcomes beginners in modeling, as well as students with substantive experience. William &amp; Mary students come to the club from many different majors. The Executive Board is grateful for the overwhelming faculty support for the club's mission. We will continue to facilitate engagement with alumni and other financial modeling experts both in-person and via video conference to benefit club members.
         </p>
       </div>


### PR DESCRIPTION
## Summary
- ensure About page background paragraph is centered by constraining width and centering via Tailwind classes

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c02bbc4a4833389fbb22aa4841ecb