### PR TITLE
Fix intro text overflow on mobile

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -71,8 +71,8 @@ main h6 {
 }
 
 #intro-message {
-  white-space: nowrap;
-  max-width: none;
+  white-space: normal;
+  max-width: 100%;
 }
 
 /* Uniform section header sizing to match "Who We Are" */


### PR DESCRIPTION
## Summary
- allow intro tagline to wrap within the screen on small devices

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c03612af08333b10c221465c2e8d6