### PR TITLE
Center paragraph text across site

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -57,10 +57,10 @@ p {
   max-width: 65ch;
   margin-left: auto;
   margin-right: auto;
+  text-align: center;
 }
 
-/* Center text for paragraphs and headings */
-main p,
+/* Center text for headings */
 main h1,
 main h2,
 main h3,


### PR DESCRIPTION
## Summary
- Center paragraph text across the site via CSS
- Keep heading centering rules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689c050505cc8333997dfa7f3c854922