### PR TITLE
Center body text with left-aligned paragraphs

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -14,6 +14,7 @@ body {
   color: var(--openai-white) !important;
   overflow-x: hidden;
   padding-top: 8rem;
+  text-align: center;
 }
 
 /* Navigation uses default system fonts to keep non-nav text in Inter */
@@ -57,7 +58,7 @@ p {
   max-width: 65ch;
   margin-left: auto;
   margin-right: auto;
-  text-align: center;
+  text-align: left;
 }
 
 /* Center text for headings */


### PR DESCRIPTION
## Summary
- Center all site text by default via `body { text-align: center; }`
- Keep paragraph content readable by overriding to `text-align: left`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c06cbfa34833398444ec13373fb98