### PR TITLE
Center leadership and meetings sections

### DIFF
--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -43,10 +43,10 @@
 
   <main class="flex-grow">
     <section class="py-8 glass m-4">
-      <div class="max-w-3xl text-center mx-auto">
+      <div class="max-w-3xl mx-auto">
         <h1 class="text-3xl font-bold mb-4 text-center">Meetings</h1>
-        <p class="mb-8 text-center">Every meeting, we host a guest speaker with expertise in financial modeling who answers questions and provides valuable insights to help prepare students for success in finance.</p>
-        <p class="mb-8 text-center">Following the speakers, we guide members through interactive workshops with practice models and slide show presentations to build a solid foundation in financial modeling.</p>
+        <p class="mb-8 text-left">Every meeting, we host a guest speaker with expertise in financial modeling who answers questions and provides valuable insights to help prepare students for success in finance.</p>
+        <p class="mb-8 text-left">Following the speakers, we guide members through interactive workshops with practice models and slide show presentations to build a solid foundation in financial modeling.</p>
       </div>
     </section>
   </main>

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -45,7 +45,7 @@
     <section class="max-w-6xl mx-auto px-4 glass">
       <div class="max-w-3xl mx-auto">
       <h1 class="text-3xl font-bold text-center mb-6">Executive Board</h1>
-      <p class="mb-8 text-center">
+      <p class="mb-8 text-left">
         The executive board manages the day-to-day operations and strategic direction of the club. We collaborate closely to design and deliver weekly workshops, events, and networking opportunities. Each member brings financial modeling experience gained through internships in the business world, ensuring they’ve applied modeling techniques in real professional settings. Feel free to contact any of our executive board members to learn more about their specific roles and experiences!
       </p>
       </div>


### PR DESCRIPTION
## Summary
- Centered "Executive Board" and "Meetings" sections while left-aligning their descriptive text for improved readability.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c0800ef448333a7c6579e7e71cf5e