### PR TITLE
style: align background section like executive board

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -41,11 +41,11 @@
     </div>
   </nav>
 
-  <main class="flex-grow">
-    <section class="py-8 glass mx-4 mb-4 mt-0">
-      <div class="max-w-3xl px-4 mx-auto">
-        <h1 class="text-3xl font-bold mb-4 text-center">Background</h1>
-        <p class="mx-auto text-center max-w-prose">
+  <main class="flex-grow py-8">
+    <section class="glass max-w-6xl mx-auto px-4 mb-4 mt-0">
+      <div class="max-w-3xl mx-auto">
+        <h1 class="text-3xl font-bold text-center mb-6">Background</h1>
+        <p class="mb-8 text-left">
           The Financial Modeling Club was founded in early 2025 to be a welcoming environment for undergraduate students to learn about modeling and to hone their skills. The club welcomes beginners in modeling, as well as students with substantive experience. William &amp; Mary students come to the club from many different majors. The Executive Board is grateful for the overwhelming faculty support for the club's mission. We will continue to facilitate engagement with alumni and other financial modeling experts both in-person and via video conference to benefit club members.
         </p>
       </div>


### PR DESCRIPTION
## Summary
- Align Background section styling with Executive Board paragraph to keep headings centered but text left aligned

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c09b649d48333a9585c9460f74ed2