### PR TITLE
Center information paragraphs on content pages

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -45,7 +45,7 @@
     <section class="glass max-w-6xl mx-auto px-4 mb-4 mt-0">
       <div class="max-w-3xl mx-auto">
         <h1 class="text-3xl font-bold text-center mb-6">Background</h1>
-        <p class="mb-8 text-left">
+        <p class="mb-8 text-left max-w-2xl mx-auto">
           The Financial Modeling Club was founded in early 2025 to be a welcoming environment for undergraduate students to learn about modeling and to hone their skills. The club welcomes beginners in modeling, as well as students with substantive experience. William &amp; Mary students come to the club from many different majors. The Executive Board is grateful for the overwhelming faculty support for the club's mission. We will continue to facilitate engagement with alumni and other financial modeling experts both in-person and via video conference to benefit club members.
         </p>
       </div>

--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -45,8 +45,8 @@
     <section class="py-8 glass m-4">
       <div class="max-w-3xl mx-auto">
         <h1 class="text-3xl font-bold mb-4 text-center">Meetings</h1>
-        <p class="mb-8 text-left">Every meeting, we host a guest speaker with expertise in financial modeling who answers questions and provides valuable insights to help prepare students for success in finance.</p>
-        <p class="mb-8 text-left">Following the speakers, we guide members through interactive workshops with practice models and slide show presentations to build a solid foundation in financial modeling.</p>
+        <p class="mb-8 text-left max-w-2xl mx-auto">Every meeting, we host a guest speaker with expertise in financial modeling who answers questions and provides valuable insights to help prepare students for success in finance.</p>
+        <p class="mb-8 text-left max-w-2xl mx-auto">Following the speakers, we guide members through interactive workshops with practice models and slide show presentations to build a solid foundation in financial modeling.</p>
       </div>
     </section>
   </main>

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -45,7 +45,7 @@
     <section class="max-w-6xl mx-auto px-4 glass">
       <div class="max-w-3xl mx-auto">
       <h1 class="text-3xl font-bold text-center mb-6">Executive Board</h1>
-      <p class="mb-8 text-left">
+      <p class="mb-8 text-left max-w-2xl mx-auto">
         The executive board manages the day-to-day operations and strategic direction of the club. We collaborate closely to design and deliver weekly workshops, events, and networking opportunities. Each member brings financial modeling experience gained through internships in the business world, ensuring they’ve applied modeling techniques in real professional settings. Feel free to contact any of our executive board members to learn more about their specific roles and experiences!
       </p>
       </div>


### PR DESCRIPTION
## Summary
- Center background info by limiting paragraph width on About, Meetings, and Executive Board pages while keeping text left-aligned

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c0b38385083339ae17b14062f7a50