### PR TITLE
Link footer text to Boehly Center site

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -57,7 +57,7 @@
       <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
-    <div class="text-gray-600 text-sm mt-2">&copy; The Boehly Center for Excellence in Finance</div>
+    <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -56,7 +56,7 @@
       <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
-    <div class="text-gray-600 text-sm mt-2">&copy; The Boehly Center for Excellence in Finance</div>
+    <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -66,7 +66,7 @@
       <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
-    <div class="text-gray-600 text-sm mt-2">&copy; The Boehly Center for Excellence in Finance</div>
+    <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
   </footer>
 
   <script type="module" src="static/js/waveBackground.js"></script>

--- a/docs/instagram.html
+++ b/docs/instagram.html
@@ -60,7 +60,7 @@
       <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
-    <div class="text-gray-600 text-sm mt-2">&copy; The Boehly Center for Excellence in Finance</div>
+    <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/join.html
+++ b/docs/join.html
@@ -56,7 +56,7 @@
       <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
-    <div class="text-gray-600 text-sm mt-2">&copy; The Boehly Center for Excellence in Finance</div>
+    <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -191,7 +191,7 @@
       <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
-    <div class="text-gray-600 text-sm mt-2">&copy; The Boehly Center for Excellence in Finance</div>
+    <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -132,7 +132,7 @@
       <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
-    <div class="text-gray-600 text-sm mt-2">&copy; The Boehly Center for Excellence in Finance</div>
+    <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
   </footer>
 </body>
 </html>

--- a/docs/schedule.html
+++ b/docs/schedule.html
@@ -54,7 +54,7 @@
       <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
-    <div class="text-gray-600 text-sm mt-2">&copy; The Boehly Center for Excellence in Finance</div>
+    <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -61,7 +61,7 @@
       <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
-    <div class="text-gray-600 text-sm mt-2">&copy; The Boehly Center for Excellence in Finance</div>
+    <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
   </footer>
 
   <script src="static/js/scripts.js"></script>


### PR DESCRIPTION
## Summary
- Link footer text "The Boehly Center for Excellence in Finance" to the Boehly Center's student clubs page across all site pages.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c0b74f588832d84baa414795e7e78