### PR TITLE
Adjust base font size to match 90% zoom

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -4,7 +4,8 @@
   --openai-white: #FFFFFF;
 }
 html {
-  font-size: 125%;
+  /* Set base font size so that 100% browser zoom matches the old 90% */
+  font-size: 112.5%;
   overflow-x: hidden;
 }
 body {


### PR DESCRIPTION
## Summary
- Reduce root font-size to 112.5% so site at 100% zoom matches previous appearance at 90% zoom.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c0d0857dc833384e0392a5079063e