### PR TITLE
Simplify mobile nav and add quick links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -21,8 +21,8 @@
 <body class="flex flex-col min-h-screen">
   <nav class="shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="relative flex items-center justify-center py-4 h-24">
-        <a href="#home" class="absolute left-4 top-1/2 -translate-y-1/2 flex items-center">
+      <div class="relative flex flex-col items-center py-4 md:h-24 md:flex-row md:justify-center">
+        <a href="#home" class="flex items-center mb-4 md:mb-0 md:absolute md:left-4 md:top-1/2 md:-translate-y-1/2">
           <div class="logo-shimmer hover-jiggle">
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>
@@ -31,13 +31,18 @@
             <span class="block nav-title">@ William & Mary</span>
           </div>
         </a>
-        <ul class="nav-tabs space-x-4">
+        <div class="flex space-x-4 md:hidden">
+          <a href="https://calendar.google.com/calendar/embed?src=aa3e8ef9cbda489545ecfcc3ae5daee0e2b0aaf5cfbd6211699381c04be035c8%40group.calendar.google.com&amp;ctz=America%2FNew_York" class="hover-jiggle no-underline glass-button"><span>Schedule</span></a>
+          <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" class="hover-jiggle no-underline glass-button"><span>Instagram</span></a>
+          <a href="https://forms.gle/g9i47Hh5tsbSpKV19" class="hover-jiggle no-underline glass-button"><span>Sign Up</span></a>
+        </div>
+        <ul class="nav-tabs space-x-4 hidden md:flex">
           <li><a href="#home" class="hover-jiggle no-underline"><span>Home</span></a></li>
           <li><a href="#leadership" class="hover-jiggle no-underline"><span>Our Team</span></a></li>
           <li><a href="#howwework" class="hover-jiggle no-underline"><span>Meetings</span></a></li>
           <li><a href="https://calendar.google.com/calendar/embed?src=aa3e8ef9cbda489545ecfcc3ae5daee0e2b0aaf5cfbd6211699381c04be035c8%40group.calendar.google.com&amp;ctz=America%2FNew_York" class="hover-jiggle no-underline"><span>Schedule</span></a></li>
         </ul>
-        <div class="absolute right-4 top-1/2 -translate-y-1/2 flex items-center space-x-4">
+        <div class="hidden md:flex md:absolute md:right-4 md:top-1/2 md:-translate-y-1/2 items-center space-x-4">
           <a href="https://www.instagram.com/financialmodelingclubwm" target="_blank" aria-label="Follow us on Instagram">
             <span class="insta-icon logo-shimmer hover-jiggle">
               <img src="static/assets/images/Instagram_logo_2022.svg.webp" alt="Instagram logo" />


### PR DESCRIPTION
## Summary
- Center logo and hide desktop nav elements on phones
- Add glass-style Schedule, Instagram, and Sign Up buttons for mobile users

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c0be8bc1083338c07871a29374071