### PR TITLE
Prevent intro message wrapping on desktop

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -59,7 +59,7 @@
       <section class="text-center py-3">
         <div class="max-w-4xl mx-auto">
           <h1 class="text-2xl font-bold text-gray-700 text-center">Welcome to the Financial Modeling Club</h1>
-          <p id="intro-message" class="mt-2 fade-in-block text-center">Combining advice from professionals in finance with student-led workshops to develop essential financial modeling skills</p>
+          <p id="intro-message" class="mt-2 fade-in-block text-center md:whitespace-nowrap">Combining advice from professionals in finance with student-led workshops to develop essential financial modeling skills</p>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- Ensure the homepage intro message stays on one line for desktop view
- Preserve automatic wrapping of the intro message for mobile view

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c0ee92b988333b2c14bd5fcc82a4d