### PR TITLE
Increase mobile spacing between logo and menu

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -22,7 +22,7 @@
   <nav class="shadow rounded-none sticky-nav">
     <div class="max-w-7xl mx-auto px-4">
       <div class="relative flex flex-col items-center py-4 md:h-24 md:flex-row md:justify-center">
-        <a href="#home" class="flex items-center mb-4 md:mb-0 md:absolute md:left-4 md:top-1/2 md:-translate-y-1/2">
+        <a href="#home" class="flex items-center mb-6 md:mb-0 md:absolute md:left-4 md:top-1/2 md:-translate-y-1/2">
           <div class="logo-shimmer hover-jiggle">
             <img src="static/assets/images/logo.png" alt="FMC Logo" class="h-24">
           </div>


### PR DESCRIPTION
## Summary
- add more margin below header logo to separate it from the mobile menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c0f878d988333ad2a50dee757b656