### PR TITLE
Increase mobile spacing between navbar and welcome text

### DIFF
--- a/docs/static/css/glass.css
+++ b/docs/static/css/glass.css
@@ -18,6 +18,12 @@ body {
   text-align: center;
 }
 
+@media (max-width: 768px) {
+  body {
+    padding-top: 12rem;
+  }
+}
+
 /* Navigation uses default system fonts to keep non-nav text in Inter */
 nav, nav * {
   font-family: Helvetica, Arial, sans-serif;


### PR DESCRIPTION
## Summary
- Increase top padding for mobile screens to create more space between fixed navbar and content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c1057c35c8333840a401df56f3edb