### PR TITLE
Link footer privacy policy to external document

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -54,7 +54,7 @@
 
   <footer class="glass py-4 text-center">
     <div class="flex justify-center space-x-4 text-sm">
-      <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
+      <a href="https://1drv.ms/b/c/659a6e300adef325/Ea8BPZpltEtDuoSrQjxgH2gBdh6H1TtOCjt35HVkWGfgIQ?e=499TmO" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
     <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>

--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -53,7 +53,7 @@
 
   <footer class="glass py-4 text-center">
     <div class="flex justify-center space-x-4 text-sm">
-      <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
+      <a href="https://1drv.ms/b/c/659a6e300adef325/Ea8BPZpltEtDuoSrQjxgH2gBdh6H1TtOCjt35HVkWGfgIQ?e=499TmO" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
     <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -68,7 +68,7 @@
 
   <footer class="glass py-4 text-center">
     <div class="flex justify-center space-x-4 text-sm">
-      <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
+      <a href="https://1drv.ms/b/c/659a6e300adef325/Ea8BPZpltEtDuoSrQjxgH2gBdh6H1TtOCjt35HVkWGfgIQ?e=499TmO" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
     <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>

--- a/docs/instagram.html
+++ b/docs/instagram.html
@@ -57,7 +57,7 @@
 
   <footer class="glass py-4 text-center">
     <div class="flex justify-center space-x-4 text-sm">
-      <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
+      <a href="https://1drv.ms/b/c/659a6e300adef325/Ea8BPZpltEtDuoSrQjxgH2gBdh6H1TtOCjt35HVkWGfgIQ?e=499TmO" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
     <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>

--- a/docs/join.html
+++ b/docs/join.html
@@ -53,7 +53,7 @@
 
   <footer class="glass py-4 text-center">
     <div class="flex justify-center space-x-4 text-sm">
-      <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
+      <a href="https://1drv.ms/b/c/659a6e300adef325/Ea8BPZpltEtDuoSrQjxgH2gBdh6H1TtOCjt35HVkWGfgIQ?e=499TmO" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
     <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -188,7 +188,7 @@
 
   <footer class="glass py-4 text-center">
     <div class="flex justify-center space-x-4 text-sm">
-      <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
+      <a href="https://1drv.ms/b/c/659a6e300adef325/Ea8BPZpltEtDuoSrQjxgH2gBdh6H1TtOCjt35HVkWGfgIQ?e=499TmO" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
     <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -129,7 +129,7 @@
 
   <footer class="glass py-4 text-center">
     <div class="flex justify-center space-x-4 text-sm">
-      <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
+      <a href="https://1drv.ms/b/c/659a6e300adef325/Ea8BPZpltEtDuoSrQjxgH2gBdh6H1TtOCjt35HVkWGfgIQ?e=499TmO" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
     <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>

--- a/docs/schedule.html
+++ b/docs/schedule.html
@@ -51,7 +51,7 @@
 
   <footer class="glass py-4 text-center">
     <div class="flex justify-center space-x-4 text-sm">
-      <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
+      <a href="https://1drv.ms/b/c/659a6e300adef325/Ea8BPZpltEtDuoSrQjxgH2gBdh6H1TtOCjt35HVkWGfgIQ?e=499TmO" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
     <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>

--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -58,7 +58,7 @@
 
   <footer class="glass py-4 text-center">
     <div class="flex justify-center space-x-4 text-sm">
-      <a href="privacy.html" class="text-blue-500 no-underline">Privacy Policy</a>
+      <a href="https://1drv.ms/b/c/659a6e300adef325/Ea8BPZpltEtDuoSrQjxgH2gBdh6H1TtOCjt35HVkWGfgIQ?e=499TmO" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
     <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>


### PR DESCRIPTION
## Summary
- Update footer privacy policy links across site to provided external document

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c10aa9180832d96ec050ecb069034