### PR TITLE
Apply desktop-only no-wrap to intro message

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -59,7 +59,7 @@
       <section class="text-center py-3">
         <div class="max-w-4xl mx-auto">
           <h1 class="text-2xl font-bold text-gray-700 text-center">Welcome to the Financial Modeling Club</h1>
-          <p id="intro-message" class="mt-2 fade-in-block text-center md:whitespace-nowrap">Combining advice from professionals in finance with student-led workshops to develop essential financial modeling skills</p>
+          <p id="intro-message" class="mt-2 fade-in-block text-center lg:whitespace-nowrap">Combining advice from professionals in finance with student-led workshops to develop essential financial modeling skills</p>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- display intro tagline on a single line for desktop by using a large-screen no-wrap class

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c10a53b4483338dc762385ea6dca5