### PR TITLE
Fix Executive Board card layout to 3-3-1

### DIFF
--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -95,7 +95,6 @@
               </span>
             </a>
           </div>
-          <div class="basis-full h-0"></div>
           <div class="card">
             <img src="static/assets/images/Luke Archey-modified - Edited.jpg" alt="Luke X. Archey" class="mx-auto h-40 w-40 object-cover">
             <p class="mt-2 font-semibold text-center">Luke X. Archey</p>


### PR DESCRIPTION
## Summary
- Remove forced flex break in Executive Board section so cards display in 3-3-1 rows

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_b_689c122136588333994d70d69fbe1186