### PR TITLE
Remove copyright symbol from footer

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -57,7 +57,7 @@
       <a href="https://1drv.ms/b/c/659a6e300adef325/Ea8BPZpltEtDuoSrQjxgH2gBdh6H1TtOCjt35HVkWGfgIQ?e=499TmO" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
-    <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
+    <div class="text-gray-600 text-sm mt-2"><a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/howwework.html
+++ b/docs/howwework.html
@@ -56,7 +56,7 @@
       <a href="https://1drv.ms/b/c/659a6e300adef325/Ea8BPZpltEtDuoSrQjxgH2gBdh6H1TtOCjt35HVkWGfgIQ?e=499TmO" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
-    <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
+    <div class="text-gray-600 text-sm mt-2"><a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -71,7 +71,7 @@
       <a href="https://1drv.ms/b/c/659a6e300adef325/Ea8BPZpltEtDuoSrQjxgH2gBdh6H1TtOCjt35HVkWGfgIQ?e=499TmO" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
-    <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
+    <div class="text-gray-600 text-sm mt-2"><a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
   </footer>
 
   <script type="module" src="static/js/waveBackground.js"></script>

--- a/docs/instagram.html
+++ b/docs/instagram.html
@@ -60,7 +60,7 @@
       <a href="https://1drv.ms/b/c/659a6e300adef325/Ea8BPZpltEtDuoSrQjxgH2gBdh6H1TtOCjt35HVkWGfgIQ?e=499TmO" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
-    <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
+    <div class="text-gray-600 text-sm mt-2"><a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/join.html
+++ b/docs/join.html
@@ -56,7 +56,7 @@
       <a href="https://1drv.ms/b/c/659a6e300adef325/Ea8BPZpltEtDuoSrQjxgH2gBdh6H1TtOCjt35HVkWGfgIQ?e=499TmO" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
-    <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
+    <div class="text-gray-600 text-sm mt-2"><a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/leadership.html
+++ b/docs/leadership.html
@@ -190,7 +190,7 @@
       <a href="https://1drv.ms/b/c/659a6e300adef325/Ea8BPZpltEtDuoSrQjxgH2gBdh6H1TtOCjt35HVkWGfgIQ?e=499TmO" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
-    <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
+    <div class="text-gray-600 text-sm mt-2"><a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -132,7 +132,7 @@
       <a href="https://1drv.ms/b/c/659a6e300adef325/Ea8BPZpltEtDuoSrQjxgH2gBdh6H1TtOCjt35HVkWGfgIQ?e=499TmO" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
-    <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
+    <div class="text-gray-600 text-sm mt-2"><a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
   </footer>
 </body>
 </html>

--- a/docs/schedule.html
+++ b/docs/schedule.html
@@ -54,7 +54,7 @@
       <a href="https://1drv.ms/b/c/659a6e300adef325/Ea8BPZpltEtDuoSrQjxgH2gBdh6H1TtOCjt35HVkWGfgIQ?e=499TmO" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
-    <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
+    <div class="text-gray-600 text-sm mt-2"><a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
   </footer>
 
   <script src="static/js/scripts.js"></script>

--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -61,7 +61,7 @@
       <a href="https://1drv.ms/b/c/659a6e300adef325/Ea8BPZpltEtDuoSrQjxgH2gBdh6H1TtOCjt35HVkWGfgIQ?e=499TmO" class="text-blue-500 no-underline">Privacy Policy</a>
       <a href="mailto:financialmodel@wm.edu" class="text-blue-500 no-underline">financialmodel@wm.edu</a>
     </div>
-    <div class="text-gray-600 text-sm mt-2">&copy; <a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
+    <div class="text-gray-600 text-sm mt-2"><a href="https://boehlycenter.mason.wm.edu/programs-clubs/student-clubs/">The Boehly Center for Excellence in Finance</a></div>
   </footer>
 
   <script src="static/js/scripts.js"></script>


### PR DESCRIPTION
## Summary
- Remove the "©" symbol before the Boehly Center for Excellence in Finance link in the footer across all pages.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689e5b823cac832d872ef43138156a1b