### PR TITLE
Update speaker page with upcoming speaker text layout

### DIFF
--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -42,16 +42,11 @@
   </nav>
 
   <main class="flex-grow py-8 glass m-4">
-    <section class="max-w-3xl mx-auto px-4 text-center">
-      <h1 class="text-3xl font-bold mb-4 text-center">Our Next Speaker</h1>
-      <div class="card">
-        <div class="card-inner">
-          <div class="card-front flex flex-col items-center">
-            <img src="static/assets/images/f05d74eb-670c-4f1b-96ac-aa47b2dbe456.jpg" alt="Thomas C. Sawyer" class="mx-auto h-40 w-40 object-cover mb-4 block">
-            <p class="mt-2 font-semibold text-center">Thomas C. Sawyer</p>
-            <p class="mt-2 text-sm text-center">Investment Banking Associate at Piper Sandler</p>
-          </div>
-        </div>
+    <section class="max-w-3xl mx-auto px-4">
+      <h1 class="text-3xl font-bold mb-4">Speakers</h1>
+      <div class="space-y-2 text-lg">
+        <p>9/24 - Thomas C. Sawyer, Investment Banking Associate at Piper Sandler</p>
+        <p>10/1 - Lauren N Kroepfl, Structured Finance Senior at Ernst &amp; Young</p>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- replace the speaker card with a simple left-aligned list of upcoming speakers
- update the section heading to "Speakers"

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc1888f3d48330be8d1a226e99300c