### PR TITLE
Adjust guest speakers page layout

### DIFF
--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -42,11 +42,11 @@
   </nav>
 
   <main class="flex-grow py-8 glass m-4">
-    <section class="max-w-3xl mx-auto px-4">
-      <h1 class="text-3xl font-bold mb-4">Speakers</h1>
-      <div class="space-y-2 text-lg">
+    <section class="max-w-3xl mx-auto px-4 text-center pb-48">
+      <h1 class="text-3xl font-bold mb-4">Guest Speakers</h1>
+      <div class="max-w-2xl mx-auto space-y-2 text-lg text-center">
         <p>9/24 - Thomas C. Sawyer, Investment Banking Associate at Piper Sandler</p>
-        <p>10/1 - Lauren N Kroepfl, Structured Finance Senior at Ernst &amp; Young</p>
+        <p>10/1 - Lauren N. Kroepfl, Structured Finance Senior at Ernst &amp; Young</p>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- rename the speaker page heading to "Guest Speakers" and fix Lauren N. Kroepfl's name
- center-align the guest speaker details and match the description width to the meetings page while adding extra spacing above the footer

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc42d5618883308eeb5741232f7859