### PR TITLE
Add Michael Monforth to guest speakers list

### DIFF
--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -50,6 +50,7 @@
         <p>10/22 - Patrick Bisceglia, Managing Director at BDO Capital Advisors</p>
         <p>10/29 - Anthony Ferrare, Investment Banking Analyst at Matrix Capital Markets</p>
         <p>11/5 - Hasan Alqutri, Venture Capital Analyst at Blue Delta Capital Partners</p>
+        <p>2/18 - Michael Monforth, Global Head of Capital Advisory at J.P. Morgan Chase</p>
       </div>
     </section>
   </main>


### PR DESCRIPTION
### Motivation
- Ensure the Guest Speakers page lists the upcoming speaker on 2/18 in the same single-line format as other entries.

### Description
- Modified `docs/speaker.html` to add one new single-line `<p>` entry: `2/18 - Michael Monforth, Global Head of Capital Advisory at J.P. Morgan Chase` placed directly under the Hasan entry.

### Testing
- Verified the file `docs/speaker.html` contains the single added `<p>` line and that no other content was changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69979aeadf0083309f5230664193ca0c)