### PR TITLE
Remove "Chase" from guest speakers list

### DIFF
--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -50,7 +50,7 @@
         <p>10/22 - Patrick Bisceglia, Managing Director at BDO Capital Advisors</p>
         <p>10/29 - Anthony Ferrare, Investment Banking Analyst at Matrix Capital Markets</p>
         <p>11/5 - Hasan Alqutri, Venture Capital Analyst at Blue Delta Capital Partners</p>
-        <p>2/18 - Michael Monforth, Global Head of Capital Advisory at J.P. Morgan Chase</p>
+        <p>2/18 - Michael Monforth, Global Head of Capital Advisory at J.P. Morgan</p>
       </div>
     </section>
   </main>


### PR DESCRIPTION
### Motivation
- Correct the guest speaker affiliation displayed on the site by removing the trailing "Chase" so the entry reads "J.P. Morgan".

### Description
- Updated `docs/speaker.html` to change the 2/18 entry from "Michael Monforth, Global Head of Capital Advisory at J.P. Morgan Chase" to "Michael Monforth, Global Head of Capital Advisory at J.P. Morgan".

### Testing
- Verified the edit with `rg -n "Monforth|Morgan" docs/speaker.html` and committed the change; a local `python -m http.server` was started successfully but an attempted Playwright screenshot failed due to browser runtime errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69979f0039f483308e3d5edb21de29c3)