### PR TITLE
Add April 1 guest speaker (Tobin Doherty)

### DIFF
--- a/docs/speaker.html
+++ b/docs/speaker.html
@@ -51,6 +51,7 @@
         <p>10/29 - Anthony Ferrare, Investment Banking Analyst at Matrix Capital Markets</p>
         <p>11/5 - Hasan Alqutri, Venture Capital Analyst at Blue Delta Capital Partners</p>
         <p>2/18 - Michael Monforth, Global Head of Capital Advisory at J.P. Morgan</p>
+        <p>4/1 - Tobin Doherty, Investment Banking Analyst at Harris Williams</p>
       </div>
     </section>
   </main>


### PR DESCRIPTION
### Motivation
- Add Tobin Doherty as the guest speaker for April 1st, listed as an Investment Banking Analyst at Harris Williams on the site’s Guest Speakers page.

### Description
- Inserted the line `<p>4/1 - Tobin Doherty, Investment Banking Analyst at Harris Williams</p>` into `docs/speaker.html` inside the guest speakers list.

### Testing
- Ran `python -m json.tool docs/data/events.json >/tmp/events.json.check` to validate JSON, which succeeded.
- Ran `rg -n "Tobin Doherty|4/1|Harris Williams" docs/speaker.html` to verify the insertion, which succeeded.
- Ran `git diff --check` to ensure no whitespace or diff errors, which succeeded.
- Attempted `npx playwright --version` for optional screenshot tooling, but it failed due to npm registry access returning 403 in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0353a3603083308f683ed838e992b9)